### PR TITLE
remove falsely returned STATUS_BUFFER_OVERFLOW

### DIFF
--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
@@ -1785,11 +1785,8 @@ NTSTATUS query_volume_information(PDEVICE_OBJECT DeviceObject, PIRP Irp, PIO_STA
 		RtlCopyMemory(ffai->FileSystemName, name.Buffer, space);
 		Irp->IoStatus.Information = FIELD_OFFSET(FILE_FS_ATTRIBUTE_INFORMATION, FileSystemName) + space;
 			
+		Status = STATUS_SUCCESS;
 
-		if (space < zmo->name.Length)
-			Status = STATUS_BUFFER_OVERFLOW;
-		else
-			Status = STATUS_SUCCESS;
 		ASSERT(Irp->IoStatus.Information <= IrpSp->Parameters.QueryVolume.Length);
 		break;
 	case FileFsControlInformation:


### PR DESCRIPTION
possible fix for #43 

I don't know what this query was intended for, but as it is, it returns STATUS_BUFFER_OVERFLOW whenever the name of the specific dataset (e.g. "tank/ROOT/default") is longer than "NTFS" (at most) which seems not very helpful. 
This change even leads to the correct display of the volume label in the explorer. 
