### PR TITLE
check if file is cached in vnode_pager_setsize()

### DIFF
--- a/ZFSin/spl/include/sys/vnode.h
+++ b/ZFSin/spl/include/sys/vnode.h
@@ -418,10 +418,12 @@ static inline int win_has_cached_data(struct vnode *vp)
 			vp->FileHeader.AllocationSize.QuadPart = P2ROUNDUP((sz), PAGE_SIZE); \
 			vp->FileHeader.FileSize.QuadPart = (sz); \
 			vp->FileHeader.ValidDataLength.QuadPart = (sz); \
-			ccfs.AllocationSize = vp->FileHeader.AllocationSize; \
-			ccfs.FileSize = vp->FileHeader.FileSize; \
-			ccfs.ValidDataLength = vp->FileHeader.ValidDataLength; \
-			CcSetFileSizes(fileObject, &ccfs); \
+			if (CcIsFileCached(fileObject)) { \
+				ccfs.AllocationSize = vp->FileHeader.AllocationSize; \
+				ccfs.FileSize = vp->FileHeader.FileSize; \
+				ccfs.ValidDataLength = vp->FileHeader.ValidDataLength; \
+				CcSetFileSizes(fileObject, &ccfs); \
+			} \
 			ObDereferenceObject(fileObject); \
 		} \
 	} while(0)


### PR DESCRIPTION
As file caching it currently disabled (e5486e438d6b989e8c865de15fdbcc9d4a9dc7f1), CcSetFileSizes() caused a BSOD (with somewhat misleading stop code IRQL_NOT_LESS_OR_EQUAL), because CcInitializeCacheMap was not called before. This has to be checked before updating the cache.
The error occured while replacing a file in my case... 