### PR TITLE
VN_HOLD/VN_RELE cleanup, INF fix for WDK 10.0.17134.0

### DIFF
--- a/ZFSin/ZFSin.inf
+++ b/ZFSin/ZFSin.inf
@@ -22,15 +22,15 @@ ZFSin.DllFiles          = 11            ;%windir%\system32
 ;; Default install sections
 ;;
 
-[DefaultInstall]
-OptionDesc  = %ServiceDescription%
-CopyFiles   = ZFSin.DriverFiles
-;;,ZFSin.DllFiles
-RegisterDlls = shellzfsin
-CopyINF     = ZFSin.inf
-
-[DefaultInstall.Services]
-AddService  = %ServiceName%,0x802,ZFSin.Service
+;[DefaultInstall]
+;OptionDesc  = %ServiceDescription%
+;CopyFiles   = ZFSin.DriverFiles
+;;;,ZFSin.DllFiles
+;RegisterDlls = shellzfsin
+;CopyINF     = ZFSin.inf
+;
+;[DefaultInstall.Services]
+;AddService  = %ServiceName%,0x802,ZFSin.Service
 
 [Manufacturer]
 %Me%=Standard,NTamd64,NTx86

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
@@ -255,7 +255,7 @@ int zfs_find_dvp_vp(zfsvfs_t *zfsvfs, char *filename, int finalpartmaynotexist, 
 			// allow it not to exist
 			if (finalpartmaynotexist) break;
 			dprintf("failing out here\n");
-			//VN_RELE(dvp);
+			VN_RELE(dvp); // since we weren't successful, we should release dvp here
 			dvp = NULL;
 			break;
 		}
@@ -674,6 +674,7 @@ int zfs_vnop_lookup(PIRP Irp, PIO_STACK_LOCATION IrpSp, mount_t *zmo)
 	if (error) {
 
 		if (dvp) VN_RELE(dvp);
+		if (vp) VN_RELE(vp);
 
 		if (error == STATUS_REPARSE) {
 			REPARSE_DATA_BUFFER *rpb = finalname;


### PR DESCRIPTION
50d1c35
When the driver takes the code path somewhere via FLUSH_BUFFERS -> zil_commit -> zil_commit_writer -> zfs_get_done(), zgd->zgd_rl was always NULL for me. Therefore it crashed in zfs_range_unlock(). So I guess this has to be checked before zfs_range_unlock() gets called. But I'm not sure if this should happen at all or if there is something else wrong?

9b37c32
I updated my Visual Studio/Windows 10 SDK/WDK from version 10.0.16299.15 to 10.0.17134.0 and after that I got an error that says that you can not have a DefaultInstall section alongside with a Manufacturer section... therefore I commented the DefaultInstall section out, as it shouldn't be needed anyways... 
Microsoft Docs:  [Note If you are building a universal or mobile driver package, this section is not valid and should not be used. Instead, use only the INF Manufacturer Section. Using both DefaultInstall and Manufacturer sections in your INF will cause Universal INF validation failures and can lead to inconsistent installation behaviors. ](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/inf-defaultinstall-section)


ed24ca1
Some v_iocount fixes...