### PR TITLE
should acquire spin lock when accessing vp

### DIFF
--- a/ZFSin/spl/include/sys/vnode.h
+++ b/ZFSin/spl/include/sys/vnode.h
@@ -416,6 +416,8 @@ static inline int win_has_cached_data(struct vnode *vp)
 	} while(0)
 #else
 #define vnode_pager_setsize(vp, sz)  do { \
+		KIRQL OldIrql; \
+		KeAcquireSpinLock(&vp->v_spinlock, &OldIrql); \
 		vp->FileHeader.AllocationSize.QuadPart = P2ROUNDUP((sz), PAGE_SIZE); \
 		vp->FileHeader.FileSize.QuadPart = (sz); \
 		vp->FileHeader.ValidDataLength.QuadPart = (sz); \
@@ -431,6 +433,7 @@ static inline int win_has_cached_data(struct vnode *vp)
 			} \
 			ObDereferenceObject(fileObject); \
 		} \
+		KeReleaseSpinLock(&vp->v_spinlock, OldIrql); \
 	} while(0)
 #endif
 


### PR DESCRIPTION
after the n-th test I got a crash in vnode_pager_setsize, probably [here](https://github.com/jheuking/ZFSin/blob/3b5d24439bef0e9df10fc89caab81746394bdaae/ZFSin/spl/include/sys/vnode.h#L434).
At this point the debugger claimed that the PFILE_OBJECT fileObject, which is defined inside the macro, points to something that looks like a valid FILE_OBJECT, but vp->fileobject was NULL. 
So I would suspect, that somehow `vnode_decouplefileobject()` was called in a different thread simultaneously. 
Of course this shouldn't happen, so we should grab a lock while we are accessing vp.