### PR TITLE
GetFileDriveSize() needs function prototype

### DIFF
--- a/ZFSin/zfs/include/libzfs.h
+++ b/ZFSin/zfs/include/libzfs.h
@@ -432,6 +432,7 @@ extern nvlist_t *zpool_search_import(libzfs_handle_t *, importargs_t *);
 extern nvlist_t *zpool_find_import(libzfs_handle_t *, int, char **);
 extern nvlist_t *zpool_find_import_cached(libzfs_handle_t *, const char *,
     char *, uint64_t);
+extern uint64_t GetFileDriveSize(HANDLE h);
 
 /*
  * Miscellaneous pool functions


### PR DESCRIPTION
The compiler defaults to `int GetFileDriveSize();` as function declaration, because it cannot find the function while building. Afterwards, the linker is able to find something like GetFileDriveSize, but when the function returns LONGLONG and the compiler assumes int, the result is only rubbish of course.
Unfortunately several (or all?) libX projects define error level 1... so the compiler doesn't warn about such mistakes.
Noticed the error on a virtual hard disk with *exactly* 16Gb space. In that case the queried drive size was 0x400000000, but after the function returned, the value was 0.