### PR TITLE
Add appveyor artifact nightlies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,15 @@
 version: 1.0.{build}
 image: Visual Studio 2017
-configuration: Debug
+configuration: Release
 platform: x64
 skip_branch_with_pr: true
+install:
+- cmd: set PATH="C:\Program Files (x86)\Inno Setup 5";%PATH%
 build:
-  verbosity: minimal
-
+  parallel: true
+  verbosity: detailed
+after_build:
+- cmd: copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\bin\Hostx86\x64\vcruntime140.dll" "C:\projects\zfsin\"
+- cmd: iscc "C:\projects\zfsin\zfsinstaller\ZFSInstall-release.iss" "/Ssigntoola=C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64\signtool.exe sign /a /t http://timestamp.digicert.com /fd sha1 /d $qOpenZFS on Windows$q $f" "/Ssigntoolb=C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64\signtool.exe sign /a /as /tr http://timestamp.digicert.com /td sha256 /fd sha256 /d $qOpenZFS on Windows$q $f"
+artifacts:
+- path: OpenZFSOnWindows-release.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
 - cmd: set PATH="C:\Program Files (x86)\Inno Setup 5";%PATH%
 build:
   parallel: true
-  verbosity: detailed
+  verbosity: minimal
 after_build:
 - cmd: copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\bin\Hostx86\x64\vcruntime140.dll" "C:\projects\zfsin\"
 - cmd: iscc "C:\projects\zfsin\zfsinstaller\ZFSInstall-release.iss" "/Ssigntoola=C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64\signtool.exe sign /a /t http://timestamp.digicert.com /fd sha1 /d $qOpenZFS on Windows$q $f" "/Ssigntoolb=C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64\signtool.exe sign /a /as /tr http://timestamp.digicert.com /td sha256 /fd sha256 /d $qOpenZFS on Windows$q $f"

--- a/zfsinstaller/ZFSInstall-release.iss
+++ b/zfsinstaller/ZFSInstall-release.iss
@@ -34,9 +34,11 @@ OutputDir={#SourcePath}\..
 ChangesEnvironment=true
 WizardSmallImageFile="{#SourcePath}\Small.bmp"
 WizardImageFile="{#SourcePath}\Large.bmp"
-; Tools/Configure Sign Tools -> Add -> "signtool" = "signtool.exe $p"
-SignTool=signtool sign /sha1 ab8e4f6b94cecfa4638847122b511e507e147c50 /n $qJoergen Lundman$q /t http://timestamp.digicert.com /fd sha1 /d $qOpenZFS on Windows$q $f
-SignTool=signtool sign /sha1 ab8e4f6b94cecfa4638847122b511e507e147c50 /as /n $qJoergen Lundman$q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /d $qOpenZFS on Windows$q $f
+; Tools/Configure Sign Tools -> Add -> 
+; "signtoola" = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64\signtool.exe sign /sha1 ab8e4f6b94cecfa4638847122b511e507e147c50 /n $qJoergen Lundman$q /t http://timestamp.digicert.com /fd sha1 /d $qOpenZFS on Windows$q $f"
+; "signtoolb" = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64\signtool.exe sign /sha1 ab8e4f6b94cecfa4638847122b511e507e147c50 /as /n $qJoergen Lundman$q /tr http://timestamp.digicert.com /td sha256 /fd sha256 /d $qOpenZFS on Windows$q $f"
+SignTool=signtoola
+SignTool=signtoolb
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
This does a couple of things-
1. Makes appveyor build the inno setup installer.
2. Publish the installer to appveyor artifacts, so making a nightly build
3. Changes the build from debug to release as that is needed for the installer.
4. Change from signtool arguments being in the script to being in the inno builder environment. This is needed so both appveyor and individual builders can build the installer without having to change the script.

