### PR TITLE
Wosix

### DIFF
--- a/ZFSin/zfs/cmd/zfs/zfs_main.c
+++ b/ZFSin/zfs/cmd/zfs/zfs_main.c
@@ -2587,7 +2587,7 @@ userspace_cb(void *arg, const char *domain, uid_t rid, uint64_t space)
 	if ((cb->cb_numname && cb->cb_sid2posix) || name == NULL) {
 		if (nvlist_add_uint64(props, "name", rid) != 0)
 			nomem();
-		namelen = snprintf(NULL, 0, "%u", rid);
+		namelen = snprintf(NULL, 0, "%llu", rid);
 	} else {
 		if (nvlist_add_string(props, "name", name) != 0)
 			nomem();
@@ -4014,7 +4014,7 @@ zfs_do_send(int argc, char **argv)
 		}
 	}
 
-	if (!flags.dryrun && win_isatty(STDOUT_FILENO)) {
+	if (!flags.dryrun && isatty(STDOUT_FILENO)) {
 		(void) fprintf(stderr,
 		    gettext("Error: Stream can not be written to a terminal.\n"
 		    "You must redirect standard output.\n"));
@@ -4267,7 +4267,7 @@ zfs_do_receive(int argc, char **argv)
 	}
 
 
-	if (win_isatty(STDIN_FILENO)) {
+	if (isatty(STDIN_FILENO)) {
 		(void) fprintf(stderr,
 		    gettext("Error: Backup stream can not be read "
 		    "from a terminal.\n"
@@ -5334,7 +5334,7 @@ construct_fsacl_list(boolean_t un, struct allow_opts *opts, nvlist_t **nvlp)
 				}
 			}
 
-			(void) sprintf(id, "%u", rid);
+			(void) sprintf(id, "%llu", rid);
 			who = id;
 
 			store_allow_perm(who_type, opts->local,
@@ -7116,7 +7116,7 @@ manual_mount(int argc, char **argv)
 	/* check for legacy mountpoint and complain appropriately */
 	ret = 0;
 	if (strcmp(mountpoint, ZFS_MOUNTPOINT_LEGACY) == 0) {
-		if (zmount(dataset, path, MS_OPTIONSTR | flags, MNTTYPE_ZFS,
+		if (zmount(zhp, path, MS_OPTIONSTR | flags, MNTTYPE_ZFS,
 		    NULL, 0, mntopts, sizeof (mntopts)) != 0) {
 #ifdef __APPLE__
 			if (errno == ENOTSUP && zfs_version > ZPL_VERSION) {

--- a/ZFSin/zfs/cmd/zpool/zpool_main.c
+++ b/ZFSin/zfs/cmd/zpool/zpool_main.c
@@ -8363,14 +8363,8 @@ zpool_do_events_next(ev_opts_t *opts)
 	nvlist_t *nvl;
 	int zevent_fd, ret, dropped;
 
-#ifdef WIN32
-	zevent_fd = CreateFile(ZFS_DEV, GENERIC_READ | GENERIC_WRITE,
-		0, NULL, OPEN_EXISTING, 0, NULL);
-	VERIFY(zevent_fd != INVALID_HANDLE_VALUE);
-#else
 	zevent_fd = open(ZFS_DEV, O_RDWR);
 	VERIFY(zevent_fd >= 0);
-#endif
 
 	if (!opts->scripted)
 		(void) printf(gettext("%-30s %s\n"), "TIME", "CLASS");
@@ -8395,11 +8389,7 @@ zpool_do_events_next(ev_opts_t *opts)
 		nvlist_free(nvl);
 	}
 
-#ifdef WIN32
-	VERIFY(CloseHandle(zevent_fd));
-#else
 	VERIFY(0 == close(zevent_fd));
-#endif
 	return (ret);
 }
 

--- a/ZFSin/zfs/cmd/zpool/zpool_vdev.c
+++ b/ZFSin/zfs/cmd/zpool/zpool_vdev.c
@@ -799,7 +799,7 @@ make_leaf_vdev(nvlist_t *props, const char *arg, uint64_t is_log)
 		return NULL;
 	}
 
-	PARTITION_INFORMATION partInfo;
+	//PARTITION_INFORMATION partInfo;
 	DWORD retcount = 0;
 	//int err;
 	char buf[1024];

--- a/ZFSin/zfs/cmd/zstreamdump/zstreamdump.c
+++ b/ZFSin/zfs/cmd/zstreamdump/zstreamdump.c
@@ -280,7 +280,7 @@ main(int argc, char *argv[])
 		}
 	}
 
-	if (win_isatty((uintptr_t)STDIN_FILENO)) {
+	if (isatty(STDIN_FILENO)) {
 		(void) fprintf(stderr,
 		    "Error: Backup stream can not be read "
 		    "from a terminal.\n"

--- a/ZFSin/zfs/include/libzfs_impl.h
+++ b/ZFSin/zfs/include/libzfs_impl.h
@@ -65,7 +65,7 @@ typedef struct libzfs_fru {
 
 struct libzfs_handle {
 	int libzfs_error;
-	HANDLE libzfs_fd;
+	int libzfs_fd;
 	FILE *libzfs_mnttab;
 	FILE *libzfs_sharetab;
 	zpool_handle_t *libzfs_pool_handles;

--- a/ZFSin/zfs/include/sys/efi_partition.h
+++ b/ZFSin/zfs/include/sys/efi_partition.h
@@ -233,15 +233,15 @@ struct partition64 {
 #endif
 
 #ifndef _KERNEL
-extern	int	efi_alloc_and_init(HANDLE, uint32_t, struct dk_gpt **);
-extern	int	efi_alloc_and_read(HANDLE, struct dk_gpt **);
-extern	int	efi_write(HANDLE, struct dk_gpt *);
-extern	int	efi_rescan(HANDLE);
+extern	int	efi_alloc_and_init(int, uint32_t, struct dk_gpt **);
+extern	int	efi_alloc_and_read(int, struct dk_gpt **);
+extern	int	efi_write(int, struct dk_gpt *);
+extern	int	efi_rescan(int);
 extern	void	efi_free(struct dk_gpt *);
-extern	int	efi_type(HANDLE);
+extern	int	efi_type(int);
 extern	void	efi_err_check(struct dk_gpt *);
-extern	int	efi_auto_sense(HANDLE fd, struct dk_gpt **);
-extern	int	efi_use_whole_disk(HANDLE fd);
+extern	int	efi_auto_sense(int fd, struct dk_gpt **);
+extern	int	efi_use_whole_disk(int fd);
 #endif
 
 #ifdef __cplusplus

--- a/ZFSin/zfs/include/sys/zfs_context_userland.h
+++ b/ZFSin/zfs/include/sys/zfs_context_userland.h
@@ -458,7 +458,6 @@ typedef struct vnode vnode_t;
 
 #ifdef _WIN32
 #define vnode_vid(vp) ((vp)->v_id)
-#define pwrite64 pwrite
 int vnode_getwithvid(vnode_t *vp, uint32_t id);
 int vnode_getwithref(vnode_t *vp);
 int vnode_put(vnode_t *vp);

--- a/ZFSin/zfs/lib/libshare/libshare.c
+++ b/ZFSin/zfs/lib/libshare/libshare.c
@@ -196,15 +196,9 @@ update_sharetab(sa_handle_impl_t impl_handle)
 	sa_fstype_t *fstype;
 	const char *resource;
 
-#ifdef _WIN32
-	if (mkdir("/etc/dfs") < 0 && errno != EEXIST) {
-		return;
-	}
-#else
 	if (mkdir("/etc/dfs", 0755) < 0 && errno != EEXIST) {
 		return;
 	}
-#endif
 
 	temp_fd = mkstemp(tempfile);
 

--- a/ZFSin/zfs/lib/libspl/fdatasync.c
+++ b/ZFSin/zfs/lib/libspl/fdatasync.c
@@ -19,13 +19,3 @@
  * CDDL HEADER END
  */
 
-#include <unistd.h>
-#include <fcntl.h>
-
-int
-fdatasync(int fd)
-{
-	//if (fcntl(fd, F_FULLFSYNC) == -1)
-	//	return -1;
-	return 0;
-}

--- a/ZFSin/zfs/lib/libspl/include/sys/w32_types.h
+++ b/ZFSin/zfs/lib/libspl/include/sys/w32_types.h
@@ -44,6 +44,9 @@
 #include <stdint.h>
 #include <malloc.h>
 
+/* Now replace POSIX calls with our versions. */
+#include <wosix.h>
+
 typedef enum boolean { B_FALSE=0, B_TRUE } boolean_t;
 typedef enum boolean bool_t;
 
@@ -157,9 +160,9 @@ typedef union {
 #define	FLT_MAX		3.4028234663852885981170E+38F
 #define	FLT_MIN		1.1754943508222875079688E-38F
 
-#define STDIN_FILENO  GetStdHandle(STD_INPUT_HANDLE)
-#define STDOUT_FILENO GetStdHandle(STD_OUTPUT_HANDLE)
-#define STDERR_FILENO GetStdHandle(STD_ERROR_HANDLE)
+#define STDIN_FILENO  HTOI(GetStdHandle(STD_INPUT_HANDLE))
+#define STDOUT_FILENO HTOI(GetStdHandle(STD_OUTPUT_HANDLE))
+#define STDERR_FILENO HTOI(GetStdHandle(STD_ERROR_HANDLE))
 #define O_EXLOCK 0
 
 #define bzero(b,len) (memset((b), '\0', (len)))
@@ -176,9 +179,9 @@ int posix_memalign(void **memptr, size_t alignment, size_t size);
 
 #define sleep(x) Sleep(x * 1000)
 
-int fsync(int);
-
 #define lstat _stat64
+#define unlink _unlink
+#define strdup _strdup
 
 #define MFSTYPENAMELEN  16
 #define MNAMELEN        MAXPATHLEN

--- a/ZFSin/zfs/lib/libspl/include/unistd.h
+++ b/ZFSin/zfs/lib/libspl/include/unistd.h
@@ -49,10 +49,7 @@ extern int	optopt;
 extern int	optreset;
 extern char	*optarg;
 
-int fdatasync(int fd);
-
 #include <stdarg.h>
-#define ftruncate _chsize_s
 #include <io.h>
 #include <direct.h>
 
@@ -64,24 +61,18 @@ size_t strlcat(register char* s, register const char* t, register size_t n);
 
 ssize_t getline(char** linep, size_t *linecapp, FILE* stream);
 
-int pread(int fd, void* buf, size_t nbyte, off_t offset);
 int pread_win(HANDLE h, void* buf, size_t nbyte, off_t offset);
-int pwrite(HANDLE h, const void* buf, size_t nbyte, off_t offset);
-int fstat_blk(int fd, struct _stat64* st);
 int pipe(int fildes[2]);
 char* realpath(const char* file_name, char* resolved_name);
-int win_isatty(uintptr_t h);
 int usleep(__int64 usec);
 int vasprintf(char** strp, const char* fmt, va_list ap);
 int asprintf(char** strp, const char* fmt, ...);
 int strncasecmp(char* s1, char* s2, size_t n);
-int socketpair(int* sv);
 int readlink(const char* path, char* buf, size_t bufsize);
 const char* getexecname(void);
 uint64_t geteuid(void);
 
 struct zfs_cmd;
-int ioctl(HANDLE hDevice, unsigned long request, struct zfs_cmd *zc);
 int mkstemp(char* tmpl);
 int64_t gethrtime(void);
 int gettimeofday(struct timeval* tp, struct timezone* tzp);

--- a/ZFSin/zfs/lib/libspl/include/wosix.h
+++ b/ZFSin/zfs/lib/libspl/include/wosix.h
@@ -1,0 +1,111 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+ /*
+  * Copyright(c) 2019 Jorgen Lundman <lundman@lundman.net>
+  */
+
+#ifndef WOSIX_HEADER
+#define WOSIX_HEADER
+
+/* Replace all the normal POSIX calls; open, read, write, close, lseek, fstat
+ * As we have to use HANDLEs to open devices, we add a shim-layer to handle
+ * int fd and the change in underlying API calls.
+ * First, include the header that defines them in Windows.
+ */
+#include <stdio.h>
+#include <direct.h>
+#include <sys/stat.h>
+#include <corecrt_io.h>
+
+#define HTOI(H) ((int)(unsigned __int64)(H))
+#define ITOH(I) ((HANDLE)(unsigned __int64)(I))
+
+extern int wosix_fsync(int fd);
+extern int wosix_open(const char *path, int oflag, ...);
+extern int wosix_close(int fd);
+extern int wosix_ioctl(int fd, unsigned long request, void *zc);
+extern int wosix_read(int fd, void *data, uint32_t len);
+extern int wosix_write(int fd, const void *data, uint32_t len);
+extern int wosix_isatty(int fd);
+extern int wosix_mkdir(const char *path, mode_t mode);
+extern int wosix_pwrite(int fd, const void *buf, size_t nbyte, off_t offset);
+extern int wosix_pread(int fd, void *buf, size_t nbyte, off_t offset);
+extern int wosix_fstat(int fd, struct _stat64 *st);
+extern int wosix_fstat_blk(int fd, struct _stat64 *st);
+extern uint64_t wosix_lseek(int fd, uint64_t offset, int seek);
+extern int wosix_fdatasync(int fd);
+extern int wosix_ftruncate(int fd, off_t length);
+extern int wosix_socketpair(int domain, int type, int protocol, int socket_vector[2]);
+extern int wosix_dup2(int fildes, int fildes2);
+
+#define wosix_fileno(X) (_get_osfhandle(_fileno((X))))
+
+extern FILE *wosix_fdopen(int fildes, const char *mode);
+
+ /*
+ * Thin wrapper for the POSIX IO calls, to translate to HANDLEs
+ *
+ * Currently it "hopes" that HANDLE value will fit in type "int".
+ * This could be improved in future.
+ */
+#undef  open
+#define open	wosix_open
+#undef  close
+#define close	wosix_close
+#undef  ioctl
+#define ioctl	wosix_ioctl
+#undef  lseek
+#define lseek	wosix_lseek
+#undef  fsync
+#define fsync	wosix_fsync
+#undef  read
+#define read	wosix_read
+#undef  write
+#define write	wosix_write
+#undef  fileno
+#define fileno	wosix_fileno
+#undef  isatty
+#define isatty	wosix_isatty
+#undef  mkdir
+#define mkdir	wosix_mkdir
+#undef  pread
+#define pread	wosix_pread
+#define pread64	wosix_pread
+#undef  pwrite
+#define pwrite	wosix_pwrite
+#define pwrite64	wosix_pwrite
+#undef  fstat
+#define fstat	wosix_fstat
+#undef  fstat_blk
+#define fstat_blk	wosix_fstat_blk
+#undef  fdatasync
+#define fdatasync	wosix_fdatasync
+#undef  ftruncate
+#define ftruncate	wosix_ftruncate
+#undef  socketpair
+#define socketpair	wosix_socketpair
+#undef  fdopen
+#define fdopen	wosix_fdopen
+#undef  dup2
+#define dup2	wosix_dup2
+
+#endif /* WOSIX_HEADER */

--- a/ZFSin/zfs/lib/libzfs/libzfs_crypto.c
+++ b/ZFSin/zfs/lib/libzfs/libzfs_crypto.c
@@ -135,12 +135,7 @@ get_key_material_raw(FILE *fd, const char *fsname, zfs_keyformat_t keyformat,
 #endif
 
 	*len_out = 0;
-
-#ifdef _WIN32
-	if (win_isatty(_get_osfhandle(_fileno(fd)))) {
-#else
-	if (isatty(fileno(fd)) {
-#endif
+	if (isatty(fileno(fd))) {
 		/*
 		 * handle SIGINT and ignore SIGSTP. This is necessary to
 		 * restore the state of the terminal.
@@ -224,11 +219,7 @@ get_key_material_raw(FILE *fd, const char *fsname, zfs_keyformat_t keyformat,
 	*len_out = bytes;
 
 out:
-#ifdef _WIN32
-	if (win_isatty(_get_osfhandle(_fileno(fd)))) {
-#else
 	if (isatty(fileno(fd))) {
-#endif
 		/* reset the teminal */
 		(void) tcsetattr(fileno(fd), TCSAFLUSH, &old_term);
 #ifndef _WIN32
@@ -276,11 +267,7 @@ get_key_material(libzfs_handle_t *hdl, boolean_t do_verify, boolean_t newkey,
 	switch (keyloc) {
 	case ZFS_KEYLOCATION_PROMPT:
 		fd = stdin;
-#ifdef _WIN32
-		if (win_isatty(_get_osfhandle(_fileno(fd)))) {
-#else
 		if (isatty(fileno(fd))) {
-#endif
 			can_retry = B_TRUE;
 
 			/* raw keys cannot be entered on the terminal */
@@ -386,11 +373,7 @@ get_key_material(libzfs_handle_t *hdl, boolean_t do_verify, boolean_t newkey,
 		break;
 	}
 
-#ifdef _WIN32
-	if (do_verify && win_isatty(_get_osfhandle(_fileno(fd)))) {
-#else
 	if (do_verify && isatty(fileno(fd))) {
-#endif
 		ret = get_key_material_raw(fd, fsname, keyformat, B_TRUE,
 		    newkey, &km2, &kmlen2);
 		if (ret != 0)

--- a/ZFSin/zfs/lib/libzfs/libzfs_diff.c
+++ b/ZFSin/zfs/lib/libzfs/libzfs_diff.c
@@ -558,11 +558,7 @@ teardown_differ_info(differ_info_t *di)
 	free(di->tosnap);
 	free(di->tmpsnap);
 	free(di->tomnt);
-#ifdef WIN32
-	CloseHandle(di->cleanupfd);
-#else
 	(void) close(di->cleanupfd);
-#endif
 }
 
 static int
@@ -750,14 +746,8 @@ setup_differ_info(zfs_handle_t *zhp, const char *fromsnap,
 {
 	di->zhp = zhp;
 
-#ifdef WIN32
-	di->cleanupfd = CreateFile(ZFS_DEV, GENERIC_READ | GENERIC_WRITE,
-		0, NULL, OPEN_EXISTING, 0, NULL);
-	VERIFY(di->cleanupfd != INVALID_HANDLE_VALUE);
-#else
 	di->cleanupfd = open(ZFS_DEV, O_RDWR);
 	VERIFY(di->cleanupfd >= 0);
-#endif
 
 	if (get_snapshot_names(di, fromsnap, tosnap) != 0)
 		return (-1);

--- a/ZFSin/zfs/lib/libzfs/libzfs_import.c
+++ b/ZFSin/zfs/lib/libzfs/libzfs_import.c
@@ -1093,7 +1093,7 @@ typedef struct rdsk_node {
 	char *rn_parent;
 #endif
 	int rn_num_labels;
-	HANDLE rn_dfd;
+	int rn_dfd;
 	libzfs_handle_t *rn_hdl;
 	nvlist_t *rn_config;
 	avl_tree_t *rn_avl;
@@ -1292,6 +1292,7 @@ void signal_alarm(int foo)
 }
 #endif
 
+#ifndef _WIN32
 static void
 zpool_open_func(void *arg)
 {
@@ -1452,7 +1453,9 @@ fprintf(stderr, "%s: enter\n", __func__); fflush(stderr);
 	rn->rn_config = config;
 	rn->rn_num_labels = num_labels;
 }
+#endif
 
+// Should probably rename this, and only define one.
 static void
 zpool_open_func_win(void *arg)
 {
@@ -1560,7 +1563,7 @@ zpool_open_func_win(void *arg)
 		* Try to read the disk label first so we don't have to
 		* open a bunch of minor nodes that can't have a zpool.
 		*/
-		check_slices(rn->rn_avl, fd, rn->rn_name);
+		check_slices(rn->rn_avl, HTOI(fd), rn->rn_name);
 	}
 
 	if ((zpool_read_label_win(fd, drive_len, &config, &num_labels)) != 0) {
@@ -1585,7 +1588,7 @@ zpool_open_func_win(void *arg)
  * Given a file descriptor, clear (zero) the label information.
  */
 int
-zpool_clear_label(HANDLE fd)
+zpool_clear_label(int fd)
 {
 	struct _stat64 statbuf;
 	int l;
@@ -1833,7 +1836,7 @@ zpool_find_import_impl(libzfs_handle_t *hdl, importargs_t *iarg)
 			slice->rn_name = zfs_strdup(hdl, name);
 			slice->rn_parent = zfs_strdup(hdl, path);
 			slice->rn_avl = &slice_cache;
-			slice->rn_dfd = dfd;
+			slice->rn_dfd = HTOI(dfd);
 			slice->rn_hdl = hdl;
 			slice->rn_nozpool = B_FALSE;
 			avl_add(&slice_cache, slice);

--- a/ZFSin/zfs/lib/libzfs/libzfs_util.c
+++ b/ZFSin/zfs/lib/libzfs/libzfs_util.c
@@ -1024,14 +1024,8 @@ libzfs_init(void)
 		return (NULL);
 	}
 
-#ifdef WIN32
-	hdl->libzfs_fd = CreateFile(ZFS_DEV, GENERIC_READ | GENERIC_WRITE,
-		0, NULL, OPEN_EXISTING, 0, NULL);
-	if ((hdl->libzfs_fd) == INVALID_HANDLE_VALUE) {
-#else
-	hdl->libzfs_fd = open(ZFS_DEV, O_RDWR));
+	hdl->libzfs_fd = open(ZFS_DEV, O_RDWR);
 	if (hdl->libzfs_fd < 0) {
-#endif
 
 		(void) fprintf(stderr, gettext("Unable to open %s: %s.\n"),
 		    ZFS_DEV, strerror(errno));
@@ -1067,11 +1061,8 @@ libzfs_init(void)
 #endif
 
 	if (libzfs_core_init() != 0) {
-#ifdef WIN32
-		(void) CloseHandle(hdl->libzfs_fd);
-#else
 		(void) close(hdl->libzfs_fd);
-#endif
+
 #ifdef LINUX
 		(void) fclose(hdl->libzfs_mnttab);
 #endif
@@ -1102,11 +1093,8 @@ libzfs_init(void)
 void
 libzfs_fini(libzfs_handle_t *hdl)
 {
-#ifdef WIN32
-	(void) CloseHandle(hdl->libzfs_fd);
-#else
 	(void) close(hdl->libzfs_fd);
-#endif
+
 #ifdef LINUX
 	if (hdl->libzfs_mnttab)
 #ifdef HAVE_SETMNTENT

--- a/ZFSin/zfs/lib/libzfs_core/libzfs_core.c
+++ b/ZFSin/zfs/lib/libzfs_core/libzfs_core.c
@@ -90,11 +90,8 @@
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/zfs_ioctl.h>
-#ifdef _WIN32
-static HANDLE g_fd = INVALID_HANDLE_VALUE;
-#else
+
 static int g_fd = -1;
-#endif
 static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
 static int g_refcount;
 
@@ -139,14 +136,7 @@ libzfs_core_init(void)
 {
 	(void) pthread_mutex_lock(&g_lock);
 	if (g_refcount == 0) {
-		//g_fd = open("/dev/zfs", O_RDWR);
-		g_fd = CreateFile("\\\\.\\ZFS", GENERIC_READ | GENERIC_WRITE,
-			0, NULL, OPEN_EXISTING, 0, NULL);
-
-		if (g_fd == INVALID_HANDLE_VALUE) {
-			(void) pthread_mutex_unlock(&g_lock);
-			return (errno);
-		}
+		g_fd = open(ZFS_DEV, O_RDWR);
 	}
 	g_refcount++;
 
@@ -166,10 +156,9 @@ libzfs_core_fini(void)
 	if (g_refcount > 0)
 		g_refcount--;
 
-	if (g_refcount == 0 && g_fd != INVALID_HANDLE_VALUE) {
-		//(void) close(g_fd);
-		(void)CloseHandle(g_fd);
-		g_fd = INVALID_HANDLE_VALUE;
+	if (g_refcount == 0 && g_fd != -1) {
+		(void) close(g_fd);
+		g_fd = -1;
 	}
 	(void) pthread_mutex_unlock(&g_lock);
 }
@@ -181,7 +170,7 @@ libzfs_core_fini(void)
  * can handle this, so this wrapper is not required.
  */
 static int
-zioctl(HANDLE fildes, zfs_ioc_t ioc, zfs_cmd_t *zc)
+zioctl(int fildes, zfs_ioc_t ioc, zfs_cmd_t *zc)
 {
 	return ioctl(g_fd, ioc, zc);
 }


### PR DESCRIPTION
Attempt to remove all the `#ifdef _WIN32` littering around the userland code base. The biggest changes is that we can not use the CRT calls that take `int fd;` - like `open()`. As they are not full citizens (can't open disk device nodes, nor handle the namespace lookup`.) The proper way is to use `HANDLE h = CreateFile()` to open things. 

We then wrap all the POSIX calls into our own version, and "hope" that HANDLE will fit in the smaller `int` type. Luckily, userland does not consume many file descriptors, so it has not yet been an issue. However, since the conversion use macros `HTOI()` and `ITOH()` it can be extended to handle the type conversion. (Presumable with a process style file descriptor array holding the real `HANDLE` types - like Unix already does). The challenge will be when userland passes the `int/HANDLE` to kernel.

Another option is to talk upstream into a wrapper type `typedef int z_fd;` to use everywhere we pass `int fd;` around, including `z_cmd_t` kernel passing.

There is a special case in the usage of `socketpair()` `ssread()` that still maintain a `#ifdef`.

`efi_rdwr.c` could still need cleanup. 