### PR TITLE
ZFS Windows related stability fixes

### DIFF
--- a/ZFSin/driver.c
+++ b/ZFSin/driver.c
@@ -101,7 +101,7 @@ void spl_create_hostid(HANDLE h, PUNICODE_STRING pRegistryPath)
 	Length = sizeof(KEY_VALUE_FULL_INFORMATION) + AttachKey.Length * sizeof(WCHAR) + sizeof(unsigned long);
 
 	PKEY_VALUE_FULL_INFORMATION   keyValue;
-	keyValue = ExAllocatePoolWithTag(NonPagedPool,
+	keyValue = ExAllocatePoolWithTag(NonPagedPoolNx,
 		Length,
 		'geRa');
 
@@ -225,7 +225,7 @@ int spl_kstat_registry(PUNICODE_STRING pRegistryPath, kstat_t *ksp)
 			break; // Something is wrong - or we finished
 
 		// Allocate space to hold
-		regBuffer = (PKEY_VALUE_FULL_INFORMATION)ExAllocatePoolWithTag(NonPagedPool, length, 'zfsr');
+		regBuffer = (PKEY_VALUE_FULL_INFORMATION)ExAllocatePoolWithTag(NonPagedPoolNx, length, 'zfsr');
 
 		if (regBuffer == NULL)
 			continue;

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows_mount.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows_mount.c
@@ -749,9 +749,11 @@ VOID InitVpb(__in PVPB Vpb, __in PDEVICE_OBJECT VolumeDevice)
 										+0xffff9284a03e9010
 										+0xffff928400000000
 
+*  
+*   Justification: The LPCWSTR could be non-NULL terminated when passed and causes the buffer to be overran.
 */
-NTSTATUS CreateReparsePoint(POBJECT_ATTRIBUTES poa, LPCWSTR SubstituteName,
-	LPCWSTR PrintName)
+NTSTATUS CreateReparsePoint(POBJECT_ATTRIBUTES poa, PCUNICODE_STRING SubstituteName,
+	PCUNICODE_STRING PrintName)
 {
 	HANDLE hFile;
 	IO_STATUS_BLOCK iosb;
@@ -766,18 +768,16 @@ NTSTATUS CreateReparsePoint(POBJECT_ATTRIBUTES poa, LPCWSTR SubstituteName,
 	if (0 > status)
 		return status;
 	dprintf("%s: create ok\n", __func__);
-	USHORT SubstituteNameLength = (USHORT)wcslen(SubstituteName) * sizeof (WCHAR);
-	USHORT PrintNameLength = (USHORT)wcslen(PrintName) * sizeof (WCHAR);
-	USHORT cb = 2 * sizeof(WCHAR) + FIELD_OFFSET(REPARSE_DATA_BUFFER, MountPointReparseBuffer.PathBuffer) + SubstituteNameLength + PrintNameLength;
+	USHORT cb = 2 * sizeof(WCHAR) + FIELD_OFFSET(REPARSE_DATA_BUFFER, MountPointReparseBuffer.PathBuffer) + SubstituteName->Length + PrintName->Length;
 	PREPARSE_DATA_BUFFER prdb = (PREPARSE_DATA_BUFFER)alloca(cb);
 	RtlZeroMemory(prdb, cb);
 	prdb->ReparseTag = IO_REPARSE_TAG_MOUNT_POINT;
 	prdb->ReparseDataLength = cb - REPARSE_DATA_BUFFER_HEADER_SIZE;
-	prdb->MountPointReparseBuffer.SubstituteNameLength = SubstituteNameLength;
-	prdb->MountPointReparseBuffer.PrintNameLength = PrintNameLength;
-	prdb->MountPointReparseBuffer.PrintNameOffset = SubstituteNameLength + sizeof(WCHAR);
-	memcpy(prdb->MountPointReparseBuffer.PathBuffer, SubstituteName, SubstituteNameLength);
-	memcpy(RtlOffsetToPointer(prdb->MountPointReparseBuffer.PathBuffer, SubstituteNameLength + sizeof(WCHAR)), PrintName, PrintNameLength);
+	prdb->MountPointReparseBuffer.SubstituteNameLength = SubstituteName->Length;
+	prdb->MountPointReparseBuffer.PrintNameLength = PrintName->Length;
+	prdb->MountPointReparseBuffer.PrintNameOffset = SubstituteName->Length + sizeof(WCHAR);
+	memcpy(prdb->MountPointReparseBuffer.PathBuffer, SubstituteName->Buffer, SubstituteName->Length);
+	memcpy(RtlOffsetToPointer(prdb->MountPointReparseBuffer.PathBuffer, SubstituteName->Length + sizeof(WCHAR)), PrintName->Buffer, PrintName->Length);
 	status = ZwFsControlFile(hFile, 0, 0, 0, &iosb, FSCTL_SET_REPARSE_POINT, prdb, cb, 0, 0);
 	dprintf("%s: ControlFile %d / 0x%x\n", __func__, status, status);
 
@@ -1188,7 +1188,7 @@ int zfs_vnop_mount(PDEVICE_OBJECT DiskDevice, PIRP Irp, PIO_STACK_LOCATION IrpSp
 		RtlUnicodeStringPrintf(&volStr, L"\\??\\Volume{%wZ}", vcb->uuid); // "\??\Volume{0b1bb601-af0b-32e8-a1d2-54c167af6277}"
 		InitializeObjectAttributes(&poa, &dcb->mountpoint, OBJ_KERNEL_HANDLE, NULL, NULL);
 		dprintf("Creating reparse mountpoint on '%wZ' for volume '%wZ'\n", &dcb->mountpoint, &volStr);
-		CreateReparsePoint(&poa, volStr.Buffer, vcb->name.Buffer);  // 3rd arg is visible in DOS box
+		CreateReparsePoint(&poa, &volStr, &vcb->name); // 3rd arg is visible in DOS box
 
 		// Remove drive letter?
 		// RtlUnicodeStringPrintf(&volStr, L"\\DosDevices\\E:");  // FIXME

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
@@ -270,7 +270,7 @@ void
 		WnodeSizeInstanceName +
 		WnodeSizeDataBlock;
 
-	pWnode = ExAllocatePoolWithTag(NonPagedPool, size, MP_TAG_GENERAL);
+	pWnode = ExAllocatePoolWithTag(NonPagedPoolNx, size, MP_TAG_GENERAL);
 
 	if (NULL != pWnode) {                               // Good?
 		RtlZeroMemory(pWnode, size);
@@ -366,7 +366,7 @@ wzvol_HwReportLink(__in pHW_HBA_EXT pHBAExt)
 		WnodeSizeInstanceName +
 		WnodeSizeDataBlock;
 
-	pWnode = ExAllocatePoolWithTag(NonPagedPool, size, MP_TAG_GENERAL);
+	pWnode = ExAllocatePoolWithTag(NonPagedPoolNx, size, MP_TAG_GENERAL);
 
 	if (NULL != pWnode) {                               // Good?
 		RtlZeroMemory(pWnode, size);
@@ -456,7 +456,7 @@ wzvol_HwReportLog(__in pHW_HBA_EXT pHBAExt)
 		WnodeSizeInstanceName +
 		WnodeSizeDataBlock;
 
-	pWnode = ExAllocatePoolWithTag(NonPagedPool, size, MP_TAG_GENERAL);
+	pWnode = ExAllocatePoolWithTag(NonPagedPoolNx, size, MP_TAG_GENERAL);
 
 	if (NULL != pWnode) {                               // Good?
 		RtlZeroMemory(pWnode, size);

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
@@ -250,7 +250,7 @@ ScsiGetMPIOExt(
     }
 
     if (pNextEntry==&pHBAExt->pwzvolDrvObj->ListMPIOExt) { // No match? That is, is this to be a new MPIO LUN extension?
-        pLUMPIOExt = ExAllocatePoolWithTag(NonPagedPool, sizeof(HW_LU_EXTENSION_MPIO), MP_TAG_GENERAL);
+        pLUMPIOExt = ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(HW_LU_EXTENSION_MPIO), MP_TAG_GENERAL);
 
         if (!pLUMPIOExt) {
 			dprintf("Failed to allocate HW_LU_EXTENSION_MPIO\n");
@@ -636,7 +636,7 @@ ScsiReadWriteSetup(
 	*pResult = ResultDone;                            // Assume no queuing.
 
 	pWkRtnParms =                                     // Allocate parm area for work routine.
-		(pMP_WorkRtnParms)ExAllocatePoolWithTag(NonPagedPool, sizeof(MP_WorkRtnParms), MP_TAG_GENERAL);
+		(pMP_WorkRtnParms)ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(MP_WorkRtnParms), MP_TAG_GENERAL);
 
 	if (NULL == pWkRtnParms) {
 		dprintf("ScsiReadWriteSetup Failed to allocate work parm structure\n");


### PR DESCRIPTION
Problem 1: Driver verifier breaks when ZFS tries to allocate Pool with the tag NonPagedPool                
Reason: Microsoft recommends to use NonPagedPoolNx after Windows 8 for all memory that does not need execution privilege.
Solution: Some of the places in driver were changed to request allocations from the NonPagedPoolNx.

Problem 2: Driver verifier breaks with memory access violation after calling the CreateReparsePoint() function. It causes a crash when Driver Verifier is not active. 
Reason - The LPCWSTR could be non-NULL terminated when passed in and causes the buffer to be overran.
Solution: Change LPCWSTR to PCUNICODE_STRING since there is no need for the function to recalculate the size of the buffer already built by the caller in Unicode string format.

Problem 3: Driver verifier breaks when ZFS’s dispatcher function is called at DISPATCH_LEVEL.
Reason: StorPort can call in the dispatcher at IRQL DISPACH_LEVEL but FsRtlEnterFileSystem() can only be called at IRQL<= APC_LEVEL. 
Solution: Check the IRQL level and do not call FsRtlEnterFileSystem() if it is greater than APC_LEVEL.

Problem 4: In the dispatcher() routine when the IRP is returned from a processing subroutine we sometimes get a BSOD.
Reason: The Irp pointer is accessed after returning from the dispatcher’s processing routine. When the IRP is returned with STATUS_PENDING and is already completed asynchronously (and freed) we get the memory access violation.
Solution: Do not use the Irp pointer if STATUS_PENDING is returned by the dispatcher’s subroutine.