### PR TITLE
SCSI Inquiry and VPDs are wrong

### DIFF
--- a/ZFSin/zfs/include/sys/wzvol.h
+++ b/ZFSin/zfs/include/sys/wzvol.h
@@ -34,12 +34,12 @@
 
 
 
-#define VENDOR_ID                   L"ZVOL    "
-#define VENDOR_ID_ascii             "ZVOL    "
-#define PRODUCT_ID                  L"ZVOLNAME        "
-#define PRODUCT_ID_ascii            "ZVOLNAME        "
-#define PRODUCT_REV                 L"1234"
-#define PRODUCT_REV_ascii           "1234"
+#define VENDOR_ID                   L"OpenZFS "
+#define VENDOR_ID_ascii             "OpenZFS "
+#define PRODUCT_ID                  L"WinZVOL         "
+#define PRODUCT_ID_ascii            "WinZVOL         "
+#define PRODUCT_REV                 L"1.00"
+#define PRODUCT_REV_ascii           "1.00"
 #define MP_TAG_GENERAL              'LOVZ'
 
 //#define WZOL_MAX_TARGETS            SCSI_MAXIMUM_TARGETS  // 8! A bit low


### PR DESCRIPTION
Problem: Initiators discovering zvols were not getting the correct information during their inquiry phase.
Reason: The format and content of the SCSI INQUIRY and Vital Product Data commands were not correct.
Fix: Conform to SCSI-3 specification for those commands.  Standardized the VendorId, ProductId and Revision levels to something that reflects the reality of a windows zvol "WinZVOL" being served by Vendor "OpenZFS".  Pages 0x00, 0x80 and 0x83 are supported.  A globally unique NAA cannot be returned because OpenZFS does not have a registered IEEE number and even a vendor specific NAA can't be generated to be unique and persistent across boots as only the zvol name is stored across botts (no GUID).  In lieu of that a T10 is returned, comprised of the VendorId and the full zvol name (poolname/zvolname).
ref: SSV-18296

This is how the zvols will look like after a scan and an inquiry:

sg_scan
PD8             OpenZFS   WinZVOL           1.00  zdedup/zfspool1

sg_inq pd8
standard INQUIRY:
  PQual=0  Device_type=0  RMB=0  version=0x05  [SPC-3]
  [AERC=0]  [TrmTsk=0]  NormACA=0  HiSUP=0  Resp_data_format=2
  SCCS=0  ACC=0  TPGS=0  3PC=0  Protect=0  BQue=0
  EncServ=0  MultiP=0  [MChngr=0]  [ACKREQQ=0]  Addr16=0
  [RelAdr=0]  WBus16=0  Sync=0  Linked=0  [TranDis=0]  CmdQue=1
  [SPI: Clocking=0x0  QAS=0  IUS=0]
    length=105 (0x69)   Peripheral device type: disk
 Vendor identification: OpenZFS
 Product identification: WinZVOL
 Product revision level: 1.00
 Unit serial number: zdedup/zfspool1

sg_vpd --page=0x00 pd8
Supported VPD pages VPD page:
  Supported VPD pages [sv]
  Unit serial number [sn]
  Device identification [di]

sg_vpd --page=0x80 pd8
Unit serial number VPD page:
  Unit serial number: zdedup/zfspool1

sg_vpd --page=0x83 pd8
Device Identification VPD page:
  Addressed logical unit:
    designator type: T10 vendor identification,  code set: ASCII
      vendor id: OpenZFS
      vendor specific: zdedup/zfspool1

