### PR TITLE
BSOD when SCSI RESET completes SRBs concurrently

### DIFF
--- a/ZFSin/zfs/include/sys/wzvol.h
+++ b/ZFSin/zfs/include/sys/wzvol.h
@@ -103,8 +103,10 @@ typedef struct _wzvolDriverInfo {                        // The master miniport 
 	WZVOL_REG_INFO                    wzvolRegInfo;
 	KSPIN_LOCK                     DrvInfoLock;
 	KSPIN_LOCK                     MPIOExtLock;       // Lock for ListMPIOExt, header of list of HW_LU_EXTENSION_MPIO objects, 
+	KSPIN_LOCK                     SrbExtLock;        // Lock for ListSrbExt
 	LIST_ENTRY                     ListMPHBAObj;      // Header of list of HW_HBA_EXT objects.
 	LIST_ENTRY                     ListMPIOExt;       // Header of list of HW_LU_EXTENSION_MPIO objects.
+	LIST_ENTRY					   ListSrbExt;		  // Heade rof List of HW_SRB_EXTENSION
 	PDRIVER_OBJECT                 pDriverObj;
 	ULONG                          DrvInfoNbrMPHBAObj;// Count of items in ListMPHBAObj.
 	ULONG                          DrvInfoNbrMPIOExtObj; // Count of items in ListMPIOExt.
@@ -190,6 +192,9 @@ typedef struct _HW_LU_EXTENSION {                     // LUN extension allocated
 
 typedef struct _HW_SRB_EXTENSION {
 	SCSIWMI_REQUEST_CONTEXT WmiRequestContext;
+	LIST_ENTRY  QueuedForProcessing;
+	volatile ULONG Cancelled;
+	PSCSI_REQUEST_BLOCK pSrbBackPtr;
 } HW_SRB_EXTENSION, *PHW_SRB_EXTENSION;
 
 typedef enum {


### PR DESCRIPTION
Problem: SRBs that are under processing in the zvol_read/write routines cause BSOD when an SRB_FUNCTION_RESET_xxx is processed

Cause: A deprecated StorPort routine would blindly complete all SRBs that comply with the reset criteria even though those were being accessed by the zvol logic.

Fix: Link list all SRBs at the time they are queued in the work item queue.  All cancellable SRBs are in that queue.  When the reset request comes in mark all linked SRBs conforming to the criteria as "cancelled".
The SRB is taken off the list when the work item is finally processed, checked if "cancelled" and if so complete it with SRB_STATUS_BUSY.

Additional fixes:

Miniport service IRPs were not processed correctly: one IRP in pReverseCallIrp could be forever lost and the final IRP completion did not properly initialize the IoStatus.

ref: SSV-18196