### PR TITLE
panic("%s: not initialised", __func__); in cv_timedwait_hires()

### DIFF
--- a/ZFSin/spl/module/spl/spl-kmem.c
+++ b/ZFSin/spl/module/spl/spl-kmem.c
@@ -5366,8 +5366,9 @@ spl_kmem_thread_init(void)
 							  300, INT_MAX, TASKQ_PREPOPULATE);
 
 	spl_free_thread_exit = FALSE;
-	(void) thread_create(NULL, 0, spl_free_thread, 0, 0, 0, 0, 92);
+	// zfsin/212
 	(void) cv_init(&spl_free_thread_cv, NULL, CV_DEFAULT, NULL);
+	(void) thread_create(NULL, 0, spl_free_thread, 0, 0, 0, 0, 92);
 
 	spl_event_thread_exit = FALSE;
 	(void)thread_create(NULL, 0, spl_event_thread, 0, 0, 0, 0, 92);


### PR DESCRIPTION
Problem: panic at startup time
Reason: a race condition let the thread use a variable that is initialized *after* the thread start call.
Fix: Modified the initialization sequence so it is always done before the thread is started.
closes #212 