### PR TITLE
Unlock and Free MDLs prior to freeing the IRP

### DIFF
--- a/ZFSin/zfs/module/zfs/vdev_disk.c
+++ b/ZFSin/zfs/module/zfs/vdev_disk.c
@@ -408,10 +408,18 @@ IO_COMPLETION_ROUTINE vdev_disk_io_intrxxx;
 static NTSTATUS
 vdev_disk_io_intrxxx(PDEVICE_OBJECT DeviceObject, PIRP irp, PVOID Context)
 {
-	KEVENT *kevent = Context;
-
-	//dprintf("%s: event\n", __func__);
-	KeSetEvent(kevent, 0, FALSE);
+	KeSetEvent((KEVENT *)Context, NT_SUCCESS(irp->IoStatus.Status) ? IO_DISK_INCREMENT : IO_NO_INCREMENT, FALSE);
+	// zfs/zfs-15
+	PMDL currentMdl, nextMdl;
+	for (currentMdl = irp->MdlAddress; currentMdl != NULL; currentMdl = nextMdl)
+	{
+		nextMdl = currentMdl->Next;
+		if (currentMdl->MdlFlags & MDL_PAGES_LOCKED)
+		{
+			MmUnlockPages(currentMdl);
+		}
+		IoFreeMdl(currentMdl);
+	}
 	IoFreeIrp(irp);
 	return STATUS_MORE_PROCESSING_REQUIRED;
 }


### PR DESCRIPTION
Problem:  MDLs created by vdev for I/Os are leaking.

Cause: The vdev's disk and file I/O completion routines are freeing their created IRP but did not unlock/free the MDL prior to that.   

Fix: If the backend device is using DIRECT_IO the buffer will be MDL'ed. Thus we must check for the MDL pointer and flag to tell us to unlock and free it.

ref: zfs-15