### PR TITLE
zvols don't appear in disk management

### DIFF
--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
@@ -606,6 +606,7 @@ ScsiReadWriteSetup(
 
 	// Save the SRB in a list allowing cancellation via SRB_FUNCTION_RESET_xxx
 	((PHW_SRB_EXTENSION)pSrb->SrbExtension)->pSrbBackPtr = pSrb;
+	((PHW_SRB_EXTENSION)pSrb->SrbExtension)->Cancelled = 0;
 	ExInterlockedInsertTailList(&pHBAExt->pwzvolDrvObj->ListSrbExt, &((PHW_SRB_EXTENSION)pSrb->SrbExtension)->QueuedForProcessing, &pHBAExt->pwzvolDrvObj->SrbExtLock);
 
 	// Queue work item, which will run in the System process.


### PR DESCRIPTION
A previous commit to allow for SRB cancellation (d51f558bf4939b6bb8dd228ada514d8a92aefe2c) did not initialize the Cancelled SRB flag.  That caused a random value there to erroneously treat the I/O as cancelled and SCSI BUSY returned.
This led to disk management waiting a long time (or forever) before it could complete its disks view when zvols were presented.
