### PR TITLE
Replacing all the instances of IoFreeMdl with UnlockAndFreeMDL routine

### DIFF
--- a/ZFSin/spl/module/spl/spl-windows.c
+++ b/ZFSin/spl/module/spl/spl-windows.c
@@ -199,6 +199,24 @@ fnv_32a_buf(void *buf, size_t len, uint32_t hval)
 	return hval;
 }
 
+/*
+ * Function to free a MDL chain
+ */
+void UnlockAndFreeMDL(PMDL Mdl)
+{
+	PMDL currentMdl, nextMdl;
+
+	for (currentMdl = Mdl; currentMdl != NULL; currentMdl = nextMdl)
+	{
+		nextMdl = currentMdl->Next;
+		if (currentMdl->MdlFlags & MDL_PAGES_LOCKED)
+		{
+			MmUnlockPages(currentMdl);
+		}
+		IoFreeMdl(currentMdl);
+	}
+}
+
 int
 ddi_copyin(const void *from, void *to, size_t len, int flags)
 {
@@ -236,7 +254,7 @@ ddi_copyin(const void *from, void *to, size_t len, int flags)
 		goto end;
 	}
 
-	mdl = IoAllocateMdl((void *)from, len, FALSE, TRUE, NULL);
+	mdl = IoAllocateMdl((void *)from, len, FALSE, FALSE, NULL);
 	if (!mdl) {
 		error = STATUS_INSUFFICIENT_RESOURCES;
 		goto end;
@@ -272,8 +290,7 @@ ddi_copyin(const void *from, void *to, size_t len, int flags)
 
 out:
 	if (mdl) {
-		MmUnlockPages(mdl);
-		IoFreeMdl(mdl);
+		UnlockAndFreeMDL(mdl);
 		mdl = NULL;
 	}
 
@@ -302,7 +319,7 @@ ddi_copyout(const void *from, void *to, size_t len, int flags)
 
 	//dprintf("SPL: trying windows copyout: %p:%d\n", to, len);
 
-	mdl = IoAllocateMdl(to, len, FALSE, TRUE, NULL);
+	mdl = IoAllocateMdl(to, len, FALSE, FALSE, NULL);
 	if (!mdl) {
 		error = STATUS_INSUFFICIENT_RESOURCES;
 		dprintf("SPL: copyout failed to allocate mdl\n");
@@ -319,8 +336,6 @@ ddi_copyout(const void *from, void *to, size_t len, int flags)
 	if (error != 0) {
 		dprintf("SPL: Exception while locking outBuf 0X%08X\n",
 			error);
-		IoFreeMdl(mdl);
-		mdl = NULL;
 		goto out;
 	}
 
@@ -336,8 +351,7 @@ ddi_copyout(const void *from, void *to, size_t len, int flags)
 	//dprintf("SPL: copyout return %d (%d bytes)\n", error, len);
 out:
 	if (mdl) {
-		MmUnlockPages(mdl);
-		IoFreeMdl(mdl);
+		UnlockAndFreeMDL(mdl);
 		mdl = NULL;
 	}
 
@@ -384,7 +398,7 @@ ddi_copysetup(void *to, size_t len, void **out_buffer, PMDL *out_mdl)
 		goto out;
 	}
 
-	mdl = IoAllocateMdl(to, len, FALSE, TRUE, NULL);
+	mdl = IoAllocateMdl(to, len, FALSE, FALSE, NULL);
 	if (!mdl) {
 		error = STATUS_INSUFFICIENT_RESOURCES;
 		dprintf("SPL: copyout failed to allocate mdl\n");
@@ -401,8 +415,6 @@ ddi_copysetup(void *to, size_t len, void **out_buffer, PMDL *out_mdl)
 	if (error != 0) {
 		dprintf("SPL: Exception while locking outBuf 0X%08X\n",
 			error);
-		IoFreeMdl(mdl);
-		mdl = NULL;
 		goto out;
 	}
 
@@ -419,8 +431,7 @@ ddi_copysetup(void *to, size_t len, void **out_buffer, PMDL *out_mdl)
 
 out:
 	if (mdl) {
-		MmUnlockPages(mdl);
-		IoFreeMdl(mdl);
+		UnlockAndFreeMDL(mdl);
 		mdl = NULL;
 	}
 

--- a/ZFSin/spl/module/spl/spl-windows.c
+++ b/ZFSin/spl/module/spl/spl-windows.c
@@ -202,7 +202,7 @@ fnv_32a_buf(void *buf, size_t len, uint32_t hval)
 /*
  * Function to free a MDL chain
  */
-void UnlockAndFreeMDL(PMDL Mdl)
+void UnlockAndFreeMdl(PMDL Mdl)
 {
 	PMDL currentMdl, nextMdl;
 
@@ -251,13 +251,13 @@ ddi_copyin(const void *from, void *to, size_t len, int flags)
 	}
 	if (error) {
 		dprintf("SPL: Exception while accessing inBuf 0X%08X\n", error);
-		goto end;
+		goto out;
 	}
 
 	mdl = IoAllocateMdl((void *)from, len, FALSE, FALSE, NULL);
 	if (!mdl) {
 		error = STATUS_INSUFFICIENT_RESOURCES;
-		goto end;
+		goto out;
 	}
 
 	try {
@@ -269,8 +269,6 @@ ddi_copyin(const void *from, void *to, size_t len, int flags)
 	}
 	if (error) {
 		dprintf("SPL: Exception while locking inBuf 0X%08X\n", error);
-		IoFreeMdl(mdl);
-		mdl = NULL;
 		goto out;
 	}
 
@@ -290,11 +288,9 @@ ddi_copyin(const void *from, void *to, size_t len, int flags)
 
 out:
 	if (mdl) {
-		UnlockAndFreeMDL(mdl);
-		mdl = NULL;
+		UnlockAndFreeMdl(mdl);
 	}
 
-end:
 	return error;
 }
 
@@ -351,8 +347,7 @@ ddi_copyout(const void *from, void *to, size_t len, int flags)
 	//dprintf("SPL: copyout return %d (%d bytes)\n", error, len);
 out:
 	if (mdl) {
-		UnlockAndFreeMDL(mdl);
-		mdl = NULL;
+		UnlockAndFreeMdl(mdl);
 	}
 
 	return error;
@@ -431,8 +426,7 @@ ddi_copysetup(void *to, size_t len, void **out_buffer, PMDL *out_mdl)
 
 out:
 	if (mdl) {
-		UnlockAndFreeMDL(mdl);
-		mdl = NULL;
+		UnlockAndFreeMdl(mdl);
 	}
 
 	return error;

--- a/ZFSin/zfs/module/zfs/vdev_disk.c
+++ b/ZFSin/zfs/module/zfs/vdev_disk.c
@@ -44,6 +44,8 @@
 
 static void vdev_disk_close(vdev_t *);
 
+extern void UnlockAndFreeMDL(PMDL);
+
 static void
 vdev_disk_alloc(vdev_t *vd)
 {
@@ -410,16 +412,7 @@ vdev_disk_io_intrxxx(PDEVICE_OBJECT DeviceObject, PIRP irp, PVOID Context)
 {
 	KeSetEvent((KEVENT *)Context, NT_SUCCESS(irp->IoStatus.Status) ? IO_DISK_INCREMENT : IO_NO_INCREMENT, FALSE);
 	// zfs/zfs-15
-	PMDL currentMdl, nextMdl;
-	for (currentMdl = irp->MdlAddress; currentMdl != NULL; currentMdl = nextMdl)
-	{
-		nextMdl = currentMdl->Next;
-		if (currentMdl->MdlFlags & MDL_PAGES_LOCKED)
-		{
-			MmUnlockPages(currentMdl);
-		}
-		IoFreeMdl(currentMdl);
-	}
+	UnlockAndFreeMDL(irp->MdlAddress);
 	IoFreeIrp(irp);
 	return STATUS_MORE_PROCESSING_REQUIRED;
 }

--- a/ZFSin/zfs/module/zfs/vdev_disk.c
+++ b/ZFSin/zfs/module/zfs/vdev_disk.c
@@ -44,7 +44,7 @@
 
 static void vdev_disk_close(vdev_t *);
 
-extern void UnlockAndFreeMDL(PMDL);
+extern void UnlockAndFreeMdl(PMDL);
 
 static void
 vdev_disk_alloc(vdev_t *vd)
@@ -412,7 +412,7 @@ vdev_disk_io_intrxxx(PDEVICE_OBJECT DeviceObject, PIRP irp, PVOID Context)
 {
 	KeSetEvent((KEVENT *)Context, NT_SUCCESS(irp->IoStatus.Status) ? IO_DISK_INCREMENT : IO_NO_INCREMENT, FALSE);
 	// zfs/zfs-15
-	UnlockAndFreeMDL(irp->MdlAddress);
+	UnlockAndFreeMdl(irp->MdlAddress);
 	IoFreeIrp(irp);
 	return STATUS_MORE_PROCESSING_REQUIRED;
 }

--- a/ZFSin/zfs/module/zfs/vdev_file.c
+++ b/ZFSin/zfs/module/zfs/vdev_file.c
@@ -40,6 +40,8 @@
 
 static taskq_t *vdev_file_taskq;
 
+extern void UnlockAndFreeMDL(PMDL);
+
 static void
 vdev_file_hold(vdev_t *vd)
 {
@@ -331,16 +333,7 @@ vdev_file_io_intrxxx(PDEVICE_OBJECT DeviceObject, PIRP irp, PVOID Context)
 {
 	KeSetEvent((KEVENT*)Context, NT_SUCCESS(irp->IoStatus.Status) ? IO_DISK_INCREMENT : IO_NO_INCREMENT, FALSE);
 	// zfs/zfs-15
-	PMDL currentMdl, nextMdl;
-	for (currentMdl = irp->MdlAddress; currentMdl != NULL; currentMdl = nextMdl)
-	{
-		nextMdl = currentMdl->Next;
-		if (currentMdl->MdlFlags & MDL_PAGES_LOCKED)
-		{
-			MmUnlockPages(currentMdl);
-		}
-		IoFreeMdl(currentMdl);
-	}
+	UnlockAndFreeMDL(irp->MdlAddress);
 	IoFreeIrp(irp);
 	return STATUS_MORE_PROCESSING_REQUIRED;
 }

--- a/ZFSin/zfs/module/zfs/vdev_file.c
+++ b/ZFSin/zfs/module/zfs/vdev_file.c
@@ -40,7 +40,7 @@
 
 static taskq_t *vdev_file_taskq;
 
-extern void UnlockAndFreeMDL(PMDL);
+extern void UnlockAndFreeMdl(PMDL);
 
 static void
 vdev_file_hold(vdev_t *vd)
@@ -333,7 +333,7 @@ vdev_file_io_intrxxx(PDEVICE_OBJECT DeviceObject, PIRP irp, PVOID Context)
 {
 	KeSetEvent((KEVENT*)Context, NT_SUCCESS(irp->IoStatus.Status) ? IO_DISK_INCREMENT : IO_NO_INCREMENT, FALSE);
 	// zfs/zfs-15
-	UnlockAndFreeMDL(irp->MdlAddress);
+	UnlockAndFreeMdl(irp->MdlAddress);
 	IoFreeIrp(irp);
 	return STATUS_MORE_PROCESSING_REQUIRED;
 }

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
@@ -119,6 +119,8 @@ uint64_t vnop_num_vnodes = 0;
 uint64_t zfs_disable_wincache = 0;
 #endif
 
+extern void UnlockAndFreeMDL(PMDL );
+
 BOOLEAN zfs_AcquireForLazyWrite(void *Context, BOOLEAN Wait)
 {
 	struct vnode *vp = Context;
@@ -3769,8 +3771,8 @@ void zfsdev_async_thread(void *arg)
 
 	PMDL mdl = Irp->Tail.Overlay.DriverContext[0];
 	if (mdl) {
-		MmUnlockPages(mdl);
-		IoFreeMdl(mdl);
+		UnlockAndFreeMDL(mdl);
+		mdl = NULL;
 		Irp->Tail.Overlay.DriverContext[0] = NULL;
 	}
 	void *fp = Irp->Tail.Overlay.DriverContext[1];

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
@@ -119,7 +119,7 @@ uint64_t vnop_num_vnodes = 0;
 uint64_t zfs_disable_wincache = 0;
 #endif
 
-extern void UnlockAndFreeMDL(PMDL );
+extern void UnlockAndFreeMdl(PMDL );
 
 BOOLEAN zfs_AcquireForLazyWrite(void *Context, BOOLEAN Wait)
 {
@@ -3771,8 +3771,7 @@ void zfsdev_async_thread(void *arg)
 
 	PMDL mdl = Irp->Tail.Overlay.DriverContext[0];
 	if (mdl) {
-		UnlockAndFreeMDL(mdl);
-		mdl = NULL;
+		UnlockAndFreeMdl(mdl);
 		Irp->Tail.Overlay.DriverContext[0] = NULL;
 	}
 	void *fp = Irp->Tail.Overlay.DriverContext[1];
@@ -3832,8 +3831,7 @@ NTSTATUS zfsdev_async(PDEVICE_OBJECT DeviceObject, PIRP Irp)
 	return STATUS_PENDING;
 out:	
 	if (mdl) {
-		MmUnlockPages(mdl);
-		IoFreeMdl(mdl);
+		UnlockAndFreeMdl(mdl);
 	}
 	if (fp) {
 		ObDereferenceObject(fp);


### PR DESCRIPTION
Problem: Incorrectly releasing the MDL chain was leading to memory leaks.

Cause: MDLs' first node was being released instead of all the nodes in MDL chain. Thereby leading to memory leaks.

Fix: Freeing up all the nodes in the MDL chain after unlocking each physical pages described by the MDL. We have a common routine UnlockAndFreeMDL being called wherever we need to free up the MDL list.