### PR TITLE
Go beyond 16 zvols presented to disk manager

### DIFF
--- a/ZFSin/driver.c
+++ b/ZFSin/driver.c
@@ -38,6 +38,11 @@ void ZFSin_Fini(PDRIVER_OBJECT  DriverObject)
 	kstat_osx_fini();
 	spl_stop();
 	finiDbgCircularBuffer();
+
+	if (STOR_wzvolDriverInfo.zvContextArray) {
+		ExFreePoolWithTag(STOR_wzvolDriverInfo.zvContextArray, MP_TAG_GENERAL);
+		STOR_wzvolDriverInfo.zvContextArray = NULL;
+	}
 }
 
 /*
@@ -76,7 +81,6 @@ NTSTATUS DriverEntry(_In_ PDRIVER_OBJECT  DriverObject, _In_ PUNICODE_STRING pRe
 		memcpy(STOR_MajorFunction, WIN_DriverObject->MajorFunction, sizeof(STOR_MajorFunction));
 		STOR_DriverUnload = WIN_DriverObject->DriverUnload;
 	}
-	WIN_DriverObject->DriverUnload = ZFSin_Fini;
 
 	/* Now set the Driver Callbacks to dispatcher and start ZFS */
 	WIN_DriverObject->DriverUnload = ZFSin_Fini;

--- a/ZFSin/zfs/module/zfs/zfs_ioctl.c
+++ b/ZFSin/zfs/module/zfs/zfs_ioctl.c
@@ -3945,11 +3945,11 @@ zfs_ioc_destroy(zfs_cmd_t *zc)
 #ifdef _WIN32
 		zvol_state_t *zv;
 		extern zvol_state_t *zvol_name2minor(const char *name, minor_t *minor);
-		extern void wzvol_clear_targetid(uint8_t targetid);
+		extern void wzvol_clear_targetid(uint8_t targetid, uint8_t lun);
 		zv = zvol_name2minor(zc->zc_name, NULL);
 		if (zv) {
 			zvol_close_impl(zv, FWRITE, 0, NULL);
-			wzvol_clear_targetid(zv->zv_target_id);
+			wzvol_clear_targetid(zv->zv_target_id,zv->zv_lun_id);
 		}
 #endif
 

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
@@ -597,13 +597,6 @@ ScsiOpModeSense(
 /**************************************************************************************************/     
 /*                                                                                                */     
 /**************************************************************************************************/     
-VOID ReverseIndian(UCHAR *x)
-{
-	UCHAR t;
-	UCHAR* d = (UCHAR*)x;
-	t = d[0]; d[0] = d[3]; d[3] = t; t = d[1]; d[1] = d[2]; d[2] = t;
-}
-
 UCHAR
 ScsiOpReportLuns(                                     
                  __in __out pHW_HBA_EXT         pHBAExt,   // Adapter device-object extension from StorPort.
@@ -637,8 +630,7 @@ ScsiOpReportLuns(
         }
     } // else: we chose to not report any LUN through that HBA (see FindAdapter routine).
 
-	*((ULONG*)&pLunList->LunListLength) = totalLun * sizeof(pLunList->Lun[0]);
-	ReverseIndian(pLunList->LunListLength);
+	*((ULONG*)&pLunList->LunListLength) = RtlUlongByteSwap(totalLun * sizeof(pLunList->Lun[0]));
 	pSrb->DataTransferLength = FIELD_OFFSET(LUN_LIST, Lun) + (GoodLunIdx * sizeof(pLunList->Lun[0]));
 
     return status;

--- a/ZFSin/zfs/module/zfs/zvol.c
+++ b/ZFSin/zfs/module/zfs/zvol.c
@@ -98,7 +98,7 @@ extern int zfs_bmajor;
 
 void wzvol_announce_buschange(void);
 int wzvol_assign_targetid(zvol_state_t *zv);
-void wzvol_clear_targetid(uint8_t targetid);
+void wzvol_clear_targetid(uint8_t targetid, uint8_t lun);
 
 /*
  * ZFS minor numbers can refer to either a control device instance or
@@ -1192,7 +1192,7 @@ zvol_remove_minors_impl(const char *name)
 				mutex_exit(&zfsdev_state_lock);
 				zvol_close_impl(zv, FWRITE, 0, NULL);
 				mutex_enter(&zfsdev_state_lock);
-				wzvol_clear_targetid(zv->zv_target_id);
+				wzvol_clear_targetid(zv->zv_target_id, zv->zv_lun_id);
 			}
 
 			(void) zvol_remove_zv(zv);


### PR DESCRIPTION
Opened up the zvol LUN presentation through StorPort to be able to announce up to 32640 zvols.

- By default the maximum amount of ZVOL LUNs is set to 400 (from 16 today) and customization through kstat will be added through a future change.

- Also by default the distribution to the targets is set to 32 LUNs per target.  This number will limit the affected LUNs when a SCSI target reset is issued (kstat customizable in the future).

- The SCSI Report LUNs has been fixed in order to return a list of more than 1 LUN.

- The MPIO support has been fixed to take into consideration the bCombineVirtDisks parameter and by default it is (and remains) FALSE.  This means that, no matter the amount of HBA extensions that are called by StorPort through FindAdapter, only 1 adapter will announce LUNs and service SCSI requests, and only 1 path will show up in MPIO.
When set to TRUE all adapters defined will respond to SCSI Inquiry and Report Luns, and will therefore enable those LUNs for multipathing in MPIO.
At that point the Zvol disk will show as many adapter paths as defined, set by default to failover-only with only 1 path active/optimized and others in Standby.  So when setting this parameter to TRUE users should first define the "OpenZFS WinZVOL" VendorId/ProductId in the MPIO console so they can be grabbed and bundled by MPIO.
Because ZFSin's StorPort interface is a virtual miniport, MPIO support is somewhat moot so this parameter should remain FALSE.

- The VendorSpecific field in the SCSI Inquiry command is now filled with the pathid/targetid/lunid used to present that ZVOL, unless a more valuable 20 bytes value is thought of. This is informational only and does not have functional significance.

- Removed the potentially costly call to StorPortGetLogicalUnit() and fetch the zv_state structure instead since everything we need is there and the LU extension is not necessary (kept for now).

- Changed the MapBuffers option to map all SRB's data buffers into system address space and take out the StorPortGetSystemAddress() call for I/Os.  We do not have any physical hardware to DMA to so ScatterGather lists are of no use for ZFSin.  Moreover in some instances, buffers were not mapped to system address space and could lead to BSOD so this takes care of those too.

ref: ssv-18396