### PR TITLE
Fix for miscompare issue

### DIFF
--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
@@ -701,9 +701,8 @@ wzvol_WkRtn(__in PVOID pWkParms)                          // Parm list pointer.
 	PSCSI_REQUEST_BLOCK       pSrb = pWkRtnParms->pSrb;
 	PCDB                      pCdb = (PCDB)pSrb->Cdb;
 	PHW_SRB_EXTENSION         pSrbExt = (PHW_SRB_EXTENSION)pSrb->SrbExtension;
-	ULONG                     startingSector,
-		sectorOffset,
-		lclStatus;
+	ULONGLONG                 startingSector, sectorOffset;
+	ULONG                     lclStatus;
 	PVOID                     pX = NULL;
 	UCHAR                     status;
 


### PR DESCRIPTION
**Problem:** For zvols of size 8GB (and above), we begin to see writes and reads miscompare.

**Cause:** Offsets can go beyond 32 bits for a large zvol. We were using ULONG for storing and manipulating the offsets.

**Fix:** Use ULONGLONG instead of ULONG for startingSector and sectorOffset variables.
