### PR TITLE
Fix compiler warnings (Visual Studio 2019)

### DIFF
--- a/ZFSin/spl/module/spl/spl-kmem.c
+++ b/ZFSin/spl/module/spl/spl-kmem.c
@@ -63,9 +63,9 @@
 // proxy to the machine experiencing memory pressure.
 //
 // xnu vm variables
-extern volatile unsigned int vm_page_free_wanted; // 0 by default smd
-extern unsigned int vm_page_free_min; // 3500 by default smd kern.vm_page_free_min, rarely changes
-extern volatile unsigned int vm_page_free_count; // will tend to vm_page_free_min smd
+extern volatile uint64_t vm_page_free_wanted; // 0 by default smd
+extern uint64_t vm_page_free_min; // 3500 by default smd kern.vm_page_free_min, rarely changes
+extern volatile uint64_t vm_page_free_count; // will tend to vm_page_free_min smd
 
 #define SMALL_PRESSURE_INCURSION_PAGES (vm_page_free_min >> 5)
 

--- a/ZFSin/spl/module/spl/spl-kmem.c
+++ b/ZFSin/spl/module/spl/spl-kmem.c
@@ -64,7 +64,7 @@
 //
 // xnu vm variables
 extern volatile uint64_t vm_page_free_wanted; // 0 by default smd
-extern uint64_t vm_page_free_min; // 3500 by default smd kern.vm_page_free_min, rarely changes
+extern unsigned int vm_page_free_min; // 3500 by default smd kern.vm_page_free_min, rarely changes
 extern volatile uint64_t vm_page_free_count; // will tend to vm_page_free_min smd
 
 #define SMALL_PRESSURE_INCURSION_PAGES (vm_page_free_min >> 5)
@@ -4645,7 +4645,7 @@ spl_free_thread(void *notused)
 			// trigger a reap below
 			lowmem = TRUE;
 		}
-		extern volatile unsigned int vm_page_speculative_count;
+		extern volatile uint64_t vm_page_speculative_count;
 		if ((above_min_free_bytes < 0LL && reserve_low && !early_lots_free &&
 			!memory_equilibrium && !just_alloced) ||
 		    above_min_free_bytes <= -4LL*1024LL*1024LL) {

--- a/ZFSin/spl/module/spl/spl-windows.c
+++ b/ZFSin/spl/module/spl/spl-windows.c
@@ -53,10 +53,10 @@ unsigned int max_ncpus = 0;
 uint64_t  total_memory = 0;
 uint64_t  real_total_memory = 0;
 
-volatile unsigned int vm_page_free_wanted = 0;
+volatile uint64_t vm_page_free_wanted = 0;
 volatile unsigned int vm_page_free_min = 512;
-volatile unsigned int vm_page_free_count = 5000;
-volatile unsigned int vm_page_speculative_count = 5500;
+volatile uint64_t vm_page_free_count = 5000;
+volatile uint64_t vm_page_speculative_count = 5500;
 
 uint64_t spl_GetPhysMem(void);
 

--- a/ZFSin/zfs/include/sys/efi_partition.h
+++ b/ZFSin/zfs/include/sys/efi_partition.h
@@ -233,8 +233,8 @@ struct partition64 {
 #endif
 
 #ifndef _KERNEL
-extern	int	efi_alloc_and_init(int, uint32_t, struct dk_gpt **);
-extern	int	efi_alloc_and_read(int, struct dk_gpt **);
+extern	int	efi_alloc_and_init(uint64_t, uint32_t, struct dk_gpt **);
+extern	int	efi_alloc_and_read(uint64_t, struct dk_gpt **);
 extern	int	efi_write(int, struct dk_gpt *);
 extern	int	efi_rescan(int);
 extern	void	efi_free(struct dk_gpt *);

--- a/ZFSin/zfs/include/sys/metaslab_impl.h
+++ b/ZFSin/zfs/include/sys/metaslab_impl.h
@@ -61,15 +61,15 @@ typedef struct metaslab_alloc_trace {
  * of the metaslab_alloc_trace_t record and displayed by mdb.
  */
 typedef enum trace_alloc_type {
-	TRACE_ALLOC_FAILURE	= -1ULL,
-	TRACE_TOO_SMALL		= -2ULL,
-	TRACE_FORCE_GANG	= -3ULL,
-	TRACE_NOT_ALLOCATABLE	= -4ULL,
-	TRACE_GROUP_FAILURE	= -5ULL,
-	TRACE_ENOSPC		= -6ULL,
-	TRACE_CONDENSING	= -7ULL,
-	TRACE_VDEV_ERROR	= -8ULL,
-	TRACE_DISABLED		= -9ULL,
+	TRACE_ALLOC_FAILURE	= -1LL,
+	TRACE_TOO_SMALL		= -2LL,
+	TRACE_FORCE_GANG	= -3LL,
+	TRACE_NOT_ALLOCATABLE	= -4LL,
+	TRACE_GROUP_FAILURE	= -5LL,
+	TRACE_ENOSPC		= -6LL,
+	TRACE_CONDENSING	= -7LL,
+	TRACE_VDEV_ERROR	= -8LL,
+	TRACE_DISABLED		= -9LL,
 } trace_alloc_type_t;
 
 #define	METASLAB_WEIGHT_PRIMARY		(1ULL << 63)

--- a/ZFSin/zfs/include/sys/zfs_context_userland.h
+++ b/ZFSin/zfs/include/sys/zfs_context_userland.h
@@ -223,7 +223,7 @@ extern void zk_thread_join(pthread_t tid);
  */
 #define	MTX_MAGIC	0x9522f51362a6e326ull
 #define	MTX_INIT	((void *)NULL)
-#define	MTX_DEST	((void *)-1UL)
+#define	MTX_DEST	((void *)-1LL)
 
 typedef struct kmutex {
 	void		*m_owner;

--- a/ZFSin/zfs/lib/libefi/rdwr_efi.c
+++ b/ZFSin/zfs/lib/libefi/rdwr_efi.c
@@ -122,7 +122,7 @@ int efi_debug = 1;
 int efi_debug = 0;
 #endif
 
-static int efi_read(int, struct dk_gpt *);
+static int efi_read(uint64_t, struct dk_gpt *);
 
 /*
  * Return a 32-bit CRC of the contents of the buffer.  Pre-and-post
@@ -139,7 +139,7 @@ efi_crc32(const unsigned char *buf, unsigned int size)
 }
 
 static int
-read_disk_info(int fd, diskaddr_t *capacity, uint_t *lbsize)
+read_disk_info(uint64_t fd, diskaddr_t *capacity, uint_t *lbsize)
 {
 	DISK_GEOMETRY_EX geometry_ex;
 	DWORD len; 
@@ -158,7 +158,7 @@ read_disk_info(int fd, diskaddr_t *capacity, uint_t *lbsize)
 }
 
 static int
-efi_get_info(int fd, struct dk_cinfo *dki_info)
+efi_get_info(uint64_t fd, struct dk_cinfo *dki_info)
 {
 	int rval = 0;
 #if defined(__linux__)
@@ -373,7 +373,7 @@ error:
 			    sizeof (struct dk_part))
 
 int
-efi_alloc_and_init(int fd, uint32_t nparts, struct dk_gpt **vtoc)
+efi_alloc_and_init(uint64_t fd, uint32_t nparts, struct dk_gpt **vtoc)
 {
 	diskaddr_t	capacity = 0;
 	uint_t		lbsize = 0;
@@ -444,7 +444,7 @@ efi_alloc_and_init(int fd, uint32_t nparts, struct dk_gpt **vtoc)
  * Read EFI - return partition number upon success.
  */
 int
-efi_alloc_and_read(int fd, struct dk_gpt **vtoc)
+efi_alloc_and_read(uint64_t fd, struct dk_gpt **vtoc)
 {
 	int			rval;
 	uint32_t		nparts;
@@ -682,7 +682,7 @@ check_label(int fd, dk_efi_t *dk_ioc)
 }
 
 static int
-efi_read(int fd, struct dk_gpt *vtoc)
+efi_read(uint64_t fd, struct dk_gpt *vtoc)
 {
 	int			i, j;
 	int			label_len;

--- a/ZFSin/zfs/lib/libpthread/pthread.h
+++ b/ZFSin/zfs/lib/libpthread/pthread.h
@@ -809,7 +809,7 @@ static int pthread_create(pthread_t *th, pthread_attr_t *attr, void *(* func)(vo
 	if (attr)
 	{
 		tv->p_state = attr->p_state;
-		ssize = attr->s_size;
+		ssize = (unsigned int) attr->s_size;
 	}
 
 	/* Make sure tv->h has value of -1 */
@@ -965,7 +965,7 @@ static int pthread_mutex_timedlock(pthread_mutex_t *m, struct timespec *ts)
 		if (ct > t) return ETIMEDOUT;
 
 		/* Wait on semaphore within critical section */
-		WaitForSingleObject(((struct _pthread_crit_t *)m)->sem, t - ct);
+		WaitForSingleObject(((struct _pthread_crit_t *)m)->sem, (DWORD) (t - ct));
 
 		/* Try to grab lock */
 		if (!pthread_mutex_trylock(m)) return 0;
@@ -1305,7 +1305,7 @@ static int pthread_cond_timedwait(pthread_cond_t *c, pthread_mutex_t *m, struct 
 
 	pthread_testcancel();
 
-	if (!SleepConditionVariableCS(c, m, tm)) return ETIMEDOUT;
+	if (!SleepConditionVariableCS(c, m, (DWORD)tm)) return ETIMEDOUT;
 
 	/* We can have a spurious wakeup after the timeout */
 	if (!_pthread_rel_time_in_ms(t)) return ETIMEDOUT;

--- a/ZFSin/zfs/lib/libspl/getmntany.c
+++ b/ZFSin/zfs/lib/libspl/getmntany.c
@@ -389,7 +389,7 @@ int getfsstat(struct statfs *buf, int bufsize, int flags)
 		if (h != INVALID_HANDLE_VALUE) {
 			char *dataset;
 			char cheat[1024];
-			UID = cheat;
+			UID = (MOUNTDEV_UNIQUE_ID*)cheat;
 			DWORD Size;
 			BOOL gotname = FALSE;
 

--- a/ZFSin/zfs/lib/libspl/include/wosix.h
+++ b/ZFSin/zfs/lib/libspl/include/wosix.h
@@ -45,7 +45,7 @@ extern int wosix_close(int fd);
 extern int wosix_ioctl(int fd, unsigned long request, void *zc);
 extern int wosix_read(int fd, void *data, uint32_t len);
 extern int wosix_write(int fd, const void *data, uint32_t len);
-extern int wosix_isatty(int fd);
+extern int wosix_isatty(intptr_t fd);
 extern int wosix_mkdir(const char *path, mode_t mode);
 extern int wosix_pwrite(int fd, const void *buf, size_t nbyte, off_t offset);
 extern int wosix_pread(int fd, void *buf, size_t nbyte, off_t offset);

--- a/ZFSin/zfs/lib/libspl/posix.c
+++ b/ZFSin/zfs/lib/libspl/posix.c
@@ -716,7 +716,7 @@ int tcsetattr(int fildes, int optional_actions,
 void console_echo(boolean_t willecho)
 {
 	HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
-	int constype = isatty(hStdin);
+	int constype = isatty((intptr_t)hStdin);
 	switch (constype) {
 	case 0:
 	default:
@@ -965,7 +965,7 @@ int wosix_write(int fd, const void *data, uint32_t len)
 // Extend isatty() slightly to return 1 for DOS Console, or
 // 2 for cygwin/mingw - as we will have to do different things
 // for NOECHO etc.
-int wosix_isatty(int fd)
+int wosix_isatty(intptr_t fd)
 {
 	DWORD mode;
 	HANDLE h = ITOH(fd);

--- a/ZFSin/zfs/lib/libspl/xdr_mem.c
+++ b/ZFSin/zfs/lib/libspl/xdr_mem.c
@@ -201,7 +201,7 @@ xdrmem_setpos(XDR *xdrs, uint_t pos)
 	caddr_t newaddr = xdrs->x_base + pos;
 	caddr_t lastaddr = xdrs->x_private + (uint_t)xdrs->x_handy;
 
-	if ((long)newaddr > (long)lastaddr)
+	if ((uintptr_t)newaddr > (uintptr_t)lastaddr)
 		return (FALSE);
 	xdrs->x_private = newaddr;
 	xdrs->x_handy = (int)((uintptr_t)lastaddr - (uintptr_t)newaddr);

--- a/ZFSin/zfs/lib/libzfs/libzfs_diff.c
+++ b/ZFSin/zfs/lib/libzfs/libzfs_diff.c
@@ -500,7 +500,7 @@ find_shares_object(differ_info_t *di)
 	(void) strlcpy(fullpath, di->dsmnt, MAXPATHLEN);
 	(void) strlcat(fullpath, ZDIFF_SHARESDIR, MAXPATHLEN);
 
-	if (stat(fullpath, &sb) != 0) {
+	if (stat(fullpath, (struct stat*)&sb) != 0) {
 		(void) snprintf(di->errbuf, sizeof (di->errbuf),
 		    dgettext(TEXT_DOMAIN, "Cannot stat %s"), fullpath);
 #if !defined (__APPLE__) && !defined(_WIN32)

--- a/ZFSin/zfs/lib/libzfs/libzfs_mount.c
+++ b/ZFSin/zfs/lib/libzfs/libzfs_mount.c
@@ -240,7 +240,7 @@ dir_is_empty_stat(const char *dirname)
 	 * We only want to return false if the given path is a non empty
 	 * directory, all other errors are handled elsewhere.
 	 */
-	if (stat(dirname, &st) < 0 || !S_ISDIR(st.st_mode)) {
+	if (stat(dirname, (struct stat*)&st) < 0 || !S_ISDIR(st.st_mode)) {
 		return (B_TRUE);
 	}
 

--- a/ZFSin/zfs/lib/libzfs/libzfs_pool.c
+++ b/ZFSin/zfs/lib/libzfs/libzfs_pool.c
@@ -676,7 +676,7 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			*slash = '\0';
 
 			if (strval[0] != '\0' &&
-			    (stat(strval, &statbuf) != 0 ||
+			    (stat(strval, (struct stat*) &statbuf) != 0 ||
 			    !S_ISDIR(statbuf.st_mode))) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "'%s' is not a valid directory"),
@@ -2856,9 +2856,8 @@ zpool_open_delay(int timeout, const char *path, int oflag)
 	if (path[0] == '#') {
 		uint64_t offset;
 		uint64_t len;
-		char *end = NULL;
+		char *end = (char*) path;
 
-		end = path;
 		while (end && *end == '#') end++;
 		offset = strtoull(end, &end, 10);
 		while (end && *end == '#') end++;

--- a/ZFSin/zfs/lib/libzpool/kernel.c
+++ b/ZFSin/zfs/lib/libzpool/kernel.c
@@ -740,7 +740,7 @@ vn_open(char *path, int x1, int flags, int mode, vnode_t **vpp, int x2, int x3)
 			    dsk + 1);
 	} else {
 		(void) sprintf(realpath, "%s", path);
-		if (!(flags & FCREAT) && stat(realpath, &st) == -1) {
+		if (!(flags & FCREAT) && stat(realpath, (struct stat*)&st) == -1) {
 			err = errno;
 			free(realpath);
 			return (err);

--- a/ZFSin/zfs/module/nvpair/nvpair.c
+++ b/ZFSin/zfs/module/nvpair/nvpair.c
@@ -817,7 +817,7 @@ i_get_value_size(data_type_t type, const void *data, uint_t nelem)
 		value_sz = (uint64_t)nelem * sizeof (uint64_t);
 
 		if (data != NULL) {
-			char *const *strs = data;
+			char **strs = (char**)data;
 			uint_t i;
 
 			/* no alignment requirement for strings */
@@ -937,7 +937,7 @@ nvlist_add_common(nvlist_t *nvl, const char *name,
 	case DATA_TYPE_BOOLEAN:
 		break;
 	case DATA_TYPE_STRING_ARRAY: {
-		char *const *strs = data;
+		char **strs = (char**) data;
 		char *buf = NVP_VALUE(nvp);
 		char **cstrs = (void *)buf;
 

--- a/ZFSin/zfs/module/unicode/u8_textprep.c
+++ b/ZFSin/zfs/module/unicode/u8_textprep.c
@@ -1499,7 +1499,7 @@ collect_a_seq(size_t uv, uchar_t *u8s, uchar_t **source, uchar_t *slast,
 				comb_class[last] = combining_class(uv,
 				    u8s + i, sz);
 				start[last] = i;
-				disp[last] = sz;
+				disp[last] = (uchar_t)sz;
 
 				last++;
 				i += sz;
@@ -1601,7 +1601,7 @@ COLLECT_A_HANGUL:
 TURN_STREAM_SAFE:
 					*state = U8_STATE_START;
 					comb_class[last] = 0;
-					start[last] = saved_sz;
+					start[last] = (uchar_t)saved_sz;
 					disp[last] = 2;
 					last++;
 
@@ -1627,7 +1627,7 @@ TURN_STREAM_SAFE:
 						    combining_class(uv,
 						    uts + j, sz);
 						start[last] = saved_sz + j;
-						disp[last] = sz;
+						disp[last] = (uchar_t)sz;
 
 						last++;
 						if (last >=
@@ -1646,8 +1646,8 @@ TURN_STREAM_SAFE:
 						u8s[saved_sz++] = uts[i];
 				} else {
 					comb_class[last] = i;
-					start[last] = saved_sz;
-					disp[last] = sz;
+					start[last] = (uchar_t)saved_sz;
+					disp[last] = (uchar_t)sz;
 					last++;
 
 					for (i = 0; i < sz; i++)

--- a/ZFSin/zfs/module/zfs/zfs_ioctl.c
+++ b/ZFSin/zfs/module/zfs/zfs_ioctl.c
@@ -7671,11 +7671,6 @@ zfsdev_ioctl(dev_t dev, u_long cmd, caddr_t arg, int xflag, struct proc *p)
 	nvlist_free(innvl);
 
 	//arg = Irp->UserBuffer;
-	// Assuming METHOD_NEITHER is used for Control Codes used in DeviceIoControl,
-	// the output buffer is stored in Irp->UserBuffer.
-	// In using irpSp->Parameters.DeviceIoControl.Type3InputBuffer for output buffer,
-	// we are assuming the same input buffer is used for output as well.
-	ASSERT(Irp->UserBuffer == irpSp->Parameters.DeviceIoControl.Type3InputBuffer);
 	arg = irpSp->Parameters.DeviceIoControl.Type3InputBuffer;
 	rc = ddi_copyout(zc, (void *)arg, sizeof (zfs_cmd_t), flag);
 	if (error == 0 && rc != 0) {

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
@@ -34,7 +34,6 @@
 #include <mountmgr.h>
 #include <Mountdev.h>
 #include <ntddvol.h>
-
  // I have no idea what black magic is needed to get ntifs.h to define these
 
 
@@ -1550,11 +1549,10 @@ NTSTATUS pnp_query_id(PDEVICE_OBJECT DeviceObject, PIRP Irp, PIO_STACK_LOCATION 
 
 	zmo = (mount_t *)DeviceObject->DeviceExtension;
 
-	Irp->IoStatus.Information = (ULONG_PTR) ExAllocatePoolWithTag(PagedPool, 2 * (zmo->bus_name.Length + 1), '!OIZ');
+	Irp->IoStatus.Information = (ULONG_PTR) ExAllocatePoolWithTag(PagedPool, zmo->bus_name.Length + sizeof(UNICODE_NULL), '!OIZ');
 	if (Irp->IoStatus.Information == (ULONG_PTR) NULL) return STATUS_NO_MEMORY;
 
-	RtlCopyMemory((void*)(Irp->IoStatus.Information), zmo->bus_name.Buffer, 2 * zmo->bus_name.Length);
-	((WCHAR*)(Irp->IoStatus.Information))[zmo->bus_name.Length] = L'\0';
+	RtlCopyMemory(Irp->IoStatus.Information, zmo->bus_name.Buffer, zmo->bus_name.Length);
 	dprintf("replying with '%.*S'\n", zmo->uuid.Length/sizeof(WCHAR), Irp->IoStatus.Information);
 
 	return STATUS_SUCCESS;

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows_lib.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows_lib.c
@@ -594,7 +594,7 @@ static int vnode_apply_single_ea(struct vnode *vp, struct vnode *xdvp, FILE_FULL
 		/* Write data */
 		uio_t *uio;
 		uio = uio_create(1, 0, UIO_SYSSPACE, UIO_WRITE);
-		uio_addiov(uio, ea->EaName + ea->EaNameLength + 1, ea->EaValueLength);
+		uio_addiov(uio, (user_addr_t)(ea->EaName + ea->EaNameLength + 1), ea->EaValueLength);
 		error = zfs_write(xvp, uio, 0, NULL, NULL);
 		uio_free(uio);
 	}
@@ -3378,7 +3378,7 @@ NTSTATUS ioctl_disk_get_partition_info(PDEVICE_OBJECT DeviceObject, PIRP Irp, PI
 	part->HiddenSectors = (ULONG)(1L);
 	part->RecognizedPartition = TRUE;
 	part->RewritePartition = FALSE;
-	part->PartitionType = 'ZFS';
+	part->PartitionType = 0x7F;	// 'ZFS'; // https://en.wikipedia.org/wiki/Partition_type
 
 	ZFS_EXIT(zfsvfs);
 

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows_lib.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows_lib.c
@@ -3378,7 +3378,7 @@ NTSTATUS ioctl_disk_get_partition_info(PDEVICE_OBJECT DeviceObject, PIRP Irp, PI
 	part->HiddenSectors = (ULONG)(1L);
 	part->RecognizedPartition = TRUE;
 	part->RewritePartition = FALSE;
-	part->PartitionType = 0x7F;	// 'ZFS'; // https://en.wikipedia.org/wiki/Partition_type
+	part->PartitionType = 'ZFS';
 
 	ZFS_EXIT(zfsvfs);
 

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows_mount.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows_mount.c
@@ -922,8 +922,8 @@ void generateVolumeNameMountpoint(wchar_t *vol_mpt)
 {
 	char GUID[50];
 	wchar_t wc_guid[50];
-	generateGUID(&GUID);
-	mbstowcs(&wc_guid, GUID, 50);
+	generateGUID(GUID);
+	mbstowcs(wc_guid, GUID, 50);
 	int len = _snwprintf(vol_mpt, 50, L"\\??\\Volume{%s}", wc_guid);
 }
 
@@ -1150,13 +1150,13 @@ int zfs_vnop_mount(PDEVICE_OBJECT DiskDevice, PIRP Irp, PIO_STACK_LOCATION IrpSp
 		if (!MOUNTMGR_IS_DRIVE_LETTER_A(namex)) {
 
 			namex[0] = 0;
-			status = mountmgr_get_volume_name_mountpoint(mountmgr, &dcb->device_name, &namex);
+			status = mountmgr_get_volume_name_mountpoint(mountmgr, &dcb->device_name, namex);
 			if (!MOUNTMGR_IS_VOLUME_NAME_A(namex)) {
 				// We have no volume name mountpoint for our device,
 				// so generate a valid GUID and mount the device
 				UNICODE_STRING vol_mpt;
 				wchar_t buf[50];
-				generateVolumeNameMountpoint(&buf);
+				generateVolumeNameMountpoint(buf);
 				RtlInitUnicodeString(&vol_mpt, buf);
 				status = SendVolumeCreatePoint(&dcb->device_name, &vol_mpt);
 			}


### PR DESCRIPTION
Problem: The Visual Studio 2019 compiler reports a lot of warnings in the ZFSin project. These changes are made to address some of those warnings which are genuine issues. NOTE: This change does not address all warnings in the project but a significant portion of them. 

Cause: There are diverse reasons for the warnings. For example, not using proper datatypes that adapt to the platforms (x64 vs x86) for pointers. Not converting GUID to a string (proper format) before printing, etc.

Fix: Address each warning depending on why the compiler is complaining.