### PR TITLE
Update compile VERSION and set it in registry

### DIFF
--- a/ZFSin/spl/spl_config.h
+++ b/ZFSin/spl/spl_config.h
@@ -74,7 +74,7 @@
 #define SPL_META_RELEASE "7-gc1b4a00"
 
 /* Define the project version. */
-#define SPL_META_VERSION "1.6.0"
+#define SPL_META_VERSION "0.2.3"
 
 /* Define ZFS_BOOT to enable kext load at boot */
 #define ZFS_BOOT 1

--- a/ZFSin/zfs/lib/libzfs/libzfs_util.c
+++ b/ZFSin/zfs/lib/libzfs/libzfs_util.c
@@ -2235,14 +2235,30 @@ zfs_version_userland(char *version, int len)
  * Fill given version buffer with zfs kernel version read from ZFS_SYSFS_DIR
  * Returns 0 on success, and -1 on error (with errno set)
  * "zfs.kext_version: 1.9.0-1"
+ * "zfs-kmod-0.8.1-1"
  */
 int
 zfs_version_kernel(char *version, int len)
 {
-	size_t rlen = len;
+	HKEY hKey; // SYSTEM\ControlSet001\Services\ZFSin
+	LSTATUS status = RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SYSTEM\\ControlSet001\\Services\\ZFSin", 0, KEY_READ, &hKey);
 
-	snprintf(version, len, "port me!");
+	if (status != ERROR_SUCCESS)
+		return -1;
 
+	DWORD count = len;
+	DWORD type;
+
+	status = RegQueryValueExA(hKey, "version", 0, &type, version, &count);
+	
+	RegCloseKey(hKey);
+
+	if (status == ERROR_SUCCESS &&
+		(type == REG_SZ)) {
+		return 0;
+	}
+
+	snprintf(version, len, "(registry lookup failed)");
 	return (0);
 }
 

--- a/ZFSin/zfs/zfs_config.h
+++ b/ZFSin/zfs/zfs_config.h
@@ -64,9 +64,6 @@
 /* zfs debugging enabled */
 /* #undef ZFS_DEBUG */
 
-/* Define the project alias string. */
-#define ZFS_META_ALIAS "zfs-1.6.0-1"
-
 /* Define the project author. */
 #define ZFS_META_AUTHOR "OpenZFS on OS X"
 
@@ -92,5 +89,7 @@
 #define ZFS_META_RELEASE "1"
 
 /* Define the project version. */
-#define ZFS_META_VERSION "1.6.0"
+#define ZFS_META_VERSION "0.2.3"
 
+/* Define the project alias string. */
+#define ZFS_META_ALIAS "zfs-" ZFS_META_VERSION "-" ZFS_META_RELEASE


### PR DESCRIPTION
When the kernel driver is initialised, set the compile time version
string in the registry.
System\\ControlSet001\\Services\\ZFSin\\version

Update the userland "zpool version" to query registry for kernel
version (via registry):

$ zpool version
zfs-0.2.3-1
zfs-kmod-0.2.3-1

We should also update ZFS_META_RELEASE with the git rev like upstream
does. It is generally set to the last section in the output of
git describe --always --long

It is unknown to me how Visual Studio could do that currently.

Eventually, it will look like:

zfs-1.9.4-0-gfa24877f83