### PR TITLE
Enable >=16TB (up to 7 exa byte) zvol creation

### DIFF
--- a/ZFSin/zfs/include/sys/wzvol.h
+++ b/ZFSin/zfs/include/sys/wzvol.h
@@ -316,6 +316,12 @@ ScsiOpReadCapacity(
 );
 
 UCHAR
+ScsiOpReadCapacity16(
+	IN pHW_HBA_EXT DevExt,
+	IN PSCSI_REQUEST_BLOCK Srb
+);
+
+UCHAR
 ScsiOpRead(
 	IN pHW_HBA_EXT          DevExt,
 	IN PSCSI_REQUEST_BLOCK  Srb,


### PR DESCRIPTION
Problem: Unable to create >=16 TB zvols.

Cause: Using 32-bit LBA you can only refer to 2^32 -1 blocks. With volblocksize=4K, it means the total capacity can't go beyond 16TB.

Fix: Support 64-bit LBA. With this change, I was able to create zvols upto 7 exa bytes in size. Beyond that size the numbers show up as negative in the disk management UI.