### PR TITLE
Fix zpool create returning -1 on successful creation of zpool

### DIFF
--- a/ZFSin/zfs/include/libzfs_impl.h
+++ b/ZFSin/zfs/include/libzfs_impl.h
@@ -129,8 +129,13 @@ struct zpool_handle {
 typedef enum {
 	PROTO_NFS = 0,
 	PROTO_SMB = 1,
+#ifdef __APPLE__
 	PROTO_AFP = 2,
 	PROTO_END = 3
+#else
+	PROTO_END = 2
+#endif
+
 } zfs_share_proto_t;
 
 /*

--- a/ZFSin/zfs/lib/libzfs/libzfs_mount.c
+++ b/ZFSin/zfs/lib/libzfs/libzfs_mount.c
@@ -129,14 +129,19 @@ zfs_share_proto_t smb_only[] = {
 	PROTO_END
 };
 
+#ifdef __APPLE__
 zfs_share_proto_t afp_only[] = {
 	PROTO_AFP,
 	PROTO_END
 };
+#endif
+
 zfs_share_proto_t share_all_proto[] = {
 	PROTO_NFS,
 	PROTO_SMB,
+#ifdef __APPLE__
 	PROTO_AFP,
+#endif
 	PROTO_END
 };
 
@@ -219,8 +224,10 @@ is_shared(libzfs_handle_t *hdl, const char *mountpoint, zfs_share_proto_t proto)
 					return (SHARED_NFS);
 				case PROTO_SMB:
 					return (SHARED_SMB);
+#ifdef __APPLE__
 				case PROTO_AFP:
 					return (SHARED_AFP);
+#endif
 				default:
 					return (0);
 				}
@@ -1176,12 +1183,14 @@ zfs_is_shared_smb(zfs_handle_t *zhp, char **where)
 	    PROTO_SMB) != SHARED_NOT_SHARED);
 }
 
+#ifdef __APPLE__
 boolean_t
 zfs_is_shared_afp(zfs_handle_t *zhp, char **where)
 {
 	return (zfs_is_shared_proto(zhp, where,
 	    PROTO_AFP) != SHARED_NOT_SHARED);
 }
+#endif
 
 /*
  * zfs_init_libshare(zhandle, service)
@@ -1358,11 +1367,13 @@ zfs_share_smb(zfs_handle_t *zhp)
 	return (zfs_share_proto(zhp, smb_only));
 }
 
+#ifdef __APPLE__
 int
 zfs_share_afp(zfs_handle_t *zhp)
 {
 	return (zfs_share_proto(zhp, afp_only));
 }
+#endif
 
 int
 zfs_shareall(zfs_handle_t *zhp)
@@ -1465,11 +1476,13 @@ zfs_unshare_smb(zfs_handle_t *zhp, const char *mountpoint)
 	return (zfs_unshare_proto(zhp, mountpoint, smb_only));
 }
 
+#ifdef __APPLE__
 int
 zfs_unshare_afp(zfs_handle_t *zhp, const char *mountpoint)
 {
 	return (zfs_unshare_proto(zhp, mountpoint, afp_only));
 }
+#endif
 
 /*
  * Same as zfs_unmountall(), but for NFS and SMB unshares.
@@ -1502,11 +1515,13 @@ zfs_unshareall_smb(zfs_handle_t *zhp)
 	return (zfs_unshareall_proto(zhp, smb_only));
 }
 
+#ifdef __APPLE__
 int
 zfs_unshareall_afp(zfs_handle_t *zhp)
 {
 	return (zfs_unshareall_proto(zhp, afp_only));
 }
+#endif
 
 int
 zfs_unshareall(zfs_handle_t *zhp)


### PR DESCRIPTION
Problem: The exit status code of zpool create command after successful completion returns -1

Cause: The function call sa_zfs_process_share inside zfs_share_proto function returns -1.
In function zfs_share_proto, we have for loop "for (curr_proto = proto; *curr_proto != PROTO_END; curr_proto++)", where in we iterate PROTO_END (3) times;  One of the arguments to sa_zfs_process_share is proto_table which is defined with only 2 entries (one for nfs, another for smb); (Third entry is supposedly reserved for afp but not explicitly defined in proto_table)
In the third iteration, proto_table[2] is invalid and hence returns with failure.

Fix: Since AFP protocol is available for Mac platform, we keep the code related to AFP protocol out of the build process by using #ifdef __APPLE__.