### PR TITLE
Eliminate memory allocation in zvol queueing from StorPort I/O.

### DIFF
--- a/ZFSin/zfs/include/sys/wzvol.h
+++ b/ZFSin/zfs/include/sys/wzvol.h
@@ -213,10 +213,10 @@ typedef enum {
 typedef struct _MP_WorkRtnParms {
 	pHW_HBA_EXT          pHBAExt;
 	PSCSI_REQUEST_BLOCK  pSrb;
-	PIO_WORKITEM         pQueueWorkItem;
 	PEPROCESS            pReqProcess;
 	MpWkRtnAction        Action;
 	ULONG                SecondsToDelay;
+	CHAR				 pQueueWorkItem[1]; // IO_WORKITEM structure. always at the end of this block. dynamically allocated.
 } MP_WorkRtnParms, *pMP_WorkRtnParms;
 
 enum ResultType {

--- a/ZFSin/zfs/include/sys/wzvol.h
+++ b/ZFSin/zfs/include/sys/wzvol.h
@@ -198,12 +198,6 @@ typedef struct _HW_LU_EXTENSION {                     // LUN extension allocated
 	UCHAR                 Lun;
 } HW_LU_EXTENSION, *pHW_LU_EXTENSION;
 
-typedef struct _HW_SRB_EXTENSION {
-	SCSIWMI_REQUEST_CONTEXT WmiRequestContext;
-	LIST_ENTRY  QueuedForProcessing;
-	volatile ULONG Cancelled;
-	PSCSI_REQUEST_BLOCK pSrbBackPtr;
-} HW_SRB_EXTENSION, *PHW_SRB_EXTENSION;
 
 typedef enum {
 	ActionRead,
@@ -216,8 +210,16 @@ typedef struct _MP_WorkRtnParms {
 	PEPROCESS            pReqProcess;
 	MpWkRtnAction        Action;
 	ULONG                SecondsToDelay;
-	CHAR				 pQueueWorkItem[1]; // IO_WORKITEM structure. always at the end of this block. dynamically allocated.
+	CHAR				 pQueueWorkItem[1]; // IO_WORKITEM structure: keep at the end of this block (dynamically allocated).
 } MP_WorkRtnParms, *pMP_WorkRtnParms;
+
+typedef struct _HW_SRB_EXTENSION {
+	SCSIWMI_REQUEST_CONTEXT WmiRequestContext;
+	LIST_ENTRY  QueuedForProcessing;
+	volatile ULONG Cancelled;
+	PSCSI_REQUEST_BLOCK pSrbBackPtr;
+	MP_WorkRtnParms WkRtnParms; // keep at the end of this block (pQueueWorkItem dynamically allocated). 
+} HW_SRB_EXTENSION, *PHW_SRB_EXTENSION;
 
 enum ResultType {
 	ResultDone,

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
@@ -110,7 +110,7 @@ int zvol_start(PDRIVER_OBJECT  DriverObject, PUNICODE_STRING pRegistryPath)
 
 	hwInitData.DeviceExtensionSize = sizeof(HW_HBA_EXT);
 	hwInitData.SpecificLuExtensionSize = sizeof(HW_LU_EXTENSION);
-	hwInitData.SrbExtensionSize = sizeof(HW_SRB_EXTENSION);
+	hwInitData.SrbExtensionSize = sizeof(HW_SRB_EXTENSION) + IoSizeofWorkItem(); // see MP_WorkRtnParms structure.
 
 	hwInitData.TaggedQueuing = TRUE;
 	hwInitData.AutoRequestSense = TRUE;

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
@@ -570,7 +570,7 @@ ScsiReadWriteSetup(
 	*pResult = ResultDone;                            // Assume no queuing.
 
 	pWkRtnParms =                                     // Allocate parm area for work routine.
-		(pMP_WorkRtnParms)ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(MP_WorkRtnParms), MP_TAG_GENERAL);
+		(pMP_WorkRtnParms)ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(MP_WorkRtnParms) + IoSizeofWorkItem(), MP_TAG_GENERAL);
 
 	if (NULL == pWkRtnParms) {
 		dprintf("ScsiReadWriteSetup Failed to allocate work parm structure\n");
@@ -584,15 +584,7 @@ ScsiReadWriteSetup(
 	pWkRtnParms->pSrb = pSrb;
 	pWkRtnParms->Action = ActionRead == WkRtnAction ? ActionRead : ActionWrite;
 
-	pWkRtnParms->pQueueWorkItem = IoAllocateWorkItem((PDEVICE_OBJECT)pHBAExt->pDrvObj);
-
-	if (NULL == pWkRtnParms->pQueueWorkItem) {
-		dprintf("ScsiReadWriteSetup: Failed to allocate work item\n");
-
-		ExFreePoolWithTag(pWkRtnParms, MP_TAG_GENERAL);
-
-		return SRB_STATUS_ERROR;
-	}
+	IoInitializeWorkItem((PDEVICE_OBJECT)pHBAExt->pDrvObj, (PIO_WORKITEM)pWkRtnParms->pQueueWorkItem);
 
 	// Save the SRB in a list allowing cancellation via SRB_FUNCTION_RESET_xxx
 	PHW_SRB_EXTENSION pSrbExt = pSrb->SrbExtension;
@@ -605,7 +597,7 @@ ScsiReadWriteSetup(
 
 	// Queue work item, which will run in the System process.
 
-	IoQueueWorkItem(pWkRtnParms->pQueueWorkItem, wzvol_GeneralWkRtn, DelayedWorkQueue, pWkRtnParms);
+	IoQueueWorkItem((PIO_WORKITEM)pWkRtnParms->pQueueWorkItem, wzvol_GeneralWkRtn, DelayedWorkQueue, pWkRtnParms);
 
 	*pResult = ResultQueued;                          // Indicate queuing.
 
@@ -772,10 +764,7 @@ wzvol_GeneralWkRtn(
 	pMP_WorkRtnParms        pWkRtnParms = (pMP_WorkRtnParms)pWkParms;
 
 	UNREFERENCED_PARAMETER(pDummy);
-
-	IoFreeWorkItem(pWkRtnParms->pQueueWorkItem);      // Free queue item.
-
-	pWkRtnParms->pQueueWorkItem = NULL;               // Be neat.
+	IoUninitializeWorkItem((PIO_WORKITEM)pWkRtnParms->pQueueWorkItem);
 
 	// If the next starts, it has to be stopped by a kernel debugger.
 


### PR DESCRIPTION
Use the WorkRtnParms allocation to include space for the workitem, thus eliminating an extra allocation. Used the SRB extension to include the WrkRtnParms block. no more extra dynamic allocation necessary for each zvol read/write I/O that gets queued in a work item queue.