### PR TITLE
Make vdev initialize pattern configurable

### DIFF
--- a/ZFSin/zfs/include/sys/kstat_windows.h
+++ b/ZFSin/zfs/include/sys/kstat_windows.h
@@ -151,6 +151,7 @@ typedef struct osx_kstat {
 	kstat_named_t zfs_disable_wincache;
 	kstat_named_t zfs_disable_removablemedia;
 
+	kstat_named_t zfs_vdev_initialize_value;
 } osx_kstat_t;
 
 
@@ -261,6 +262,8 @@ extern uint64_t  zfs_special_class_metadata_reserve_pct;
 
 extern uint64_t zfs_disable_wincache;
 extern uint64_t zfs_disable_removablemedia;
+
+extern uint64_t zfs_initialize_value;
 
 int        kstat_osx_init(void *);
 void       kstat_osx_fini(void);

--- a/ZFSin/zfs/module/zfs/zfs_kstat_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_kstat_windows.c
@@ -181,7 +181,7 @@ osx_kstat_t osx_kstat = {
 
 	{ "zfs_disable_wincache",		KSTAT_DATA_UINT64 },
 	{ "zfs_disable_removablemedia",		KSTAT_DATA_UINT64 },
-
+	{ "zfs_vdev_initialize_value",		KSTAT_DATA_UINT64 },
 };
 
 
@@ -391,7 +391,8 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 			ks->zfs_disable_wincache.value.ui64;
 		zfs_disable_removablemedia =
 			ks->zfs_disable_removablemedia.value.ui64;
-
+		zfs_initialize_value =
+			ks->zfs_vdev_initialize_value.value.ui64;
 	} else {
 
 		/* kstat READ */
@@ -581,7 +582,8 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 			zfs_disable_wincache;
 		ks->zfs_disable_removablemedia.value.ui64 =
 			zfs_disable_removablemedia;
-
+		ks->zfs_vdev_initialize_value.value.ui64 =
+			zfs_initialize_value;
 	}
 
 	return 0;


### PR DESCRIPTION
Added a tunable value through kstat/registry so the vdev initialize pattern can be changed from its default of 0xdeadbeefdeadbeef to something else.

Background: In some disk pooling architectures supporting thin-provisioning the storage allocation unit that comes from the backend needs to initially be zero'ed out.  So a pattern value of 0 can now be selected for that purpose.

The value is tunable through kstat.exe (non-persistent across boots) as well as the ZFSin registry (persistent)

Through kstat (to set it to 0 for example):

kstat -w zfs:0:tunable:zfs_vdev_initialize_value=0

Through the registry:

Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ZFSin\zfs_vdev_initialize_value

REG_QWORD

0

ref: ZFS-109