### PR TITLE
Fixed race condition in zfs destroy

### DIFF
--- a/ZFSin/zfs/include/sys/wzvol.h
+++ b/ZFSin/zfs/include/sys/wzvol.h
@@ -101,6 +101,12 @@ typedef struct _MP_REG_INFO {
 	ULONG            bCombineVirtDisks;  // 0 => do not combine virtual disks a la MPIO.
 } WZVOL_REG_INFO, *pWZVOL_REG_INFO;
 
+typedef struct _wzvolContext {
+	PVOID	zv;
+	PIO_REMOVE_LOCK pIoRemLock;
+	volatile LONGLONG refCnt;
+} wzvolContext, * pwzvolContext;
+
 typedef struct _wzvolDriverInfo {                        // The master miniport object. In effect, an extension of the driver object for the miniport.
 	WZVOL_REG_INFO                    wzvolRegInfo;
 	KSPIN_LOCK                     DrvInfoLock;
@@ -110,7 +116,7 @@ typedef struct _wzvolDriverInfo {                        // The master miniport 
 	LIST_ENTRY                     ListMPIOExt;       // Header of list of HW_LU_EXTENSION_MPIO objects.
 	LIST_ENTRY					   ListSrbExt;		  // Heade rof List of HW_SRB_EXTENSION
 	PDRIVER_OBJECT                 pDriverObj;
-	PVOID						*zvContextArray;
+	wzvolContext				*zvContextArray;
 	ULONG                          DrvInfoNbrMPHBAObj;// Count of items in ListMPHBAObj.
 	ULONG                          DrvInfoNbrMPIOExtObj; // Count of items in ListMPIOExt.
 	UCHAR						MaximumNumberOfLogicalUnits;

--- a/ZFSin/zfs/include/sys/zvol.h
+++ b/ZFSin/zfs/include/sys/zvol.h
@@ -73,6 +73,7 @@ typedef struct zvol_state {
 	uint64_t zv_openflags;	/* Remember flags used at open */
 	uint8_t zv_target_id;
 	uint8_t zv_lun_id;
+    void* zv_target_context; // for I/O drainage (see assign_targetid, clear_targetid)
 } zvol_state_t;
 
 enum zfs_soft_state_type {

--- a/ZFSin/zfs/module/zfs/zfs_ioctl.c
+++ b/ZFSin/zfs/module/zfs/zfs_ioctl.c
@@ -3948,8 +3948,8 @@ zfs_ioc_destroy(zfs_cmd_t *zc)
 		extern void wzvol_clear_targetid(uint8_t targetid, uint8_t lun);
 		zv = zvol_name2minor(zc->zc_name, NULL);
 		if (zv) {
+			wzvol_clear_targetid(zv->zv_target_id,zv->zv_lun_id,zv);
 			zvol_close_impl(zv, FWRITE, 0, NULL);
-			wzvol_clear_targetid(zv->zv_target_id,zv->zv_lun_id);
 		}
 #endif
 

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
@@ -86,11 +86,11 @@ int zvol_start(PDRIVER_OBJECT  DriverObject, PUNICODE_STRING pRegistryPath)
 	//pwzvolDrvInfo->MaximumNumberOfTargets = (pwzvolDrvInfo->wzvolRegInfo.NbrLUNsperHBA <= SCSI_MAXIMUM_TARGETS_PER_BUS ? pwzvolDrvInfo->wzvolRegInfo.NbrLUNsperHBA : SCSI_MAXIMUM_TARGETS_PER_BUS);
 	pwzvolDrvInfo->MaximumNumberOfLogicalUnits = (pwzvolDrvInfo->wzvolRegInfo.NbrLUNsperHBA / pwzvolDrvInfo->MaximumNumberOfTargets) + 1;
 	pwzvolDrvInfo->NumberOfBuses = 1; // supporting more would mean bigger changes in the zv_targets array. now we can go up to 32,640 zvols.
-	pwzvolDrvInfo->zvContextArray = (PVOID*)ExAllocatePoolWithTag(NonPagedPoolNx, ((SIZE_T)pwzvolDrvInfo->MaximumNumberOfTargets * pwzvolDrvInfo->MaximumNumberOfLogicalUnits * sizeof(PVOID)), MP_TAG_GENERAL);
+	pwzvolDrvInfo->zvContextArray = (wzvolContext*)ExAllocatePoolWithTag(NonPagedPoolNx, ((SIZE_T)pwzvolDrvInfo->MaximumNumberOfTargets * pwzvolDrvInfo->MaximumNumberOfLogicalUnits * sizeof(wzvolContext)), MP_TAG_GENERAL);
 	if (pwzvolDrvInfo->zvContextArray == NULL)
 		return (STATUS_NO_MEMORY);
-	RtlZeroMemory(pwzvolDrvInfo->zvContextArray, ((SIZE_T)pwzvolDrvInfo->MaximumNumberOfTargets * pwzvolDrvInfo->MaximumNumberOfLogicalUnits * sizeof(PVOID)));
-
+	RtlZeroMemory(pwzvolDrvInfo->zvContextArray, ((SIZE_T)pwzvolDrvInfo->MaximumNumberOfTargets * pwzvolDrvInfo->MaximumNumberOfLogicalUnits * (sizeof(wzvolContext))));
+		
 	RtlZeroMemory(&hwInitData, sizeof(VIRTUAL_HW_INITIALIZATION_DATA));
 
 	hwInitData.HwInitializationDataSize = sizeof(VIRTUAL_HW_INITIALIZATION_DATA);


### PR DESCRIPTION
Problem: random BSODs happen when the zv (zvol_state_t*) control block happens to be freed while outstanding I/Os are still in the StorPort acceptance pipeline.  Once I/Os make it in the zil log the close routine already makes sure to flush the zil before freeing the zv but some I/Os could still be in the path length's front end portion.

Fix: Front-end I/Os - entering through StorPort - must be be all drained before the zfs destroy command deletes the zv control block.  

Also clearing the target/lun id *before* invoking the close shuts off front-end I/Os earlier and allows for a speedier close.  
Note: Comments explaining the reference count/remove lock mechanism are embedded with code (see ref: SSV-18807 in the code).