### PR TITLE
Enabling WPP tracing in ZFSin

### DIFF
--- a/ZFSin/Trace.h
+++ b/ZFSin/Trace.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#define WPPNAME		ZFSinTraceGuid
+#define WPPGUID		c20c603c,afd4,467d,bf76,c0a4c10553df
+
+#define WPP_CONTROL_GUIDS \
+    WPP_DEFINE_CONTROL_GUID(WPPNAME,(WPPGUID), \
+        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)             /* bit  0 = 0x00000001 */ \
+        WPP_DEFINE_BIT(TRACE_DRIVER)           /* bit  1 = 0x00000002 */ \
+        WPP_DEFINE_BIT(TRACE_DEVICE)              /* bit  2 = 0x00000004 */ \
+        WPP_DEFINE_BIT(TRACE_QUEUE)           /* bit  3 = 0x00000008 */ )
+
+#ifndef WPP_CHECK_INIT
+#define WPP_CHECK_INIT
+#endif
+
+
+#define WPP_FLAGS_LEVEL_LOGGER(Flags, level)                                  \
+    WPP_LEVEL_LOGGER(Flags)
+
+#define WPP_FLAGS_LEVEL_ENABLED(Flags, level)                                 \
+    (WPP_LEVEL_ENABLED(Flags) && \
+    WPP_CONTROL(WPP_BIT_ ## Flags).Level >= level)
+
+#define WPP_LEVEL_FLAGS_LOGGER(lvl,flags) \
+           WPP_LEVEL_LOGGER(flags)
+
+#define WPP_LEVEL_FLAGS_ENABLED(lvl, flags) \
+           (WPP_LEVEL_ENABLED(flags) && WPP_CONTROL(WPP_BIT_ ## flags).Level >= lvl)
+
+// begin_wpp config
+// FUNC dprintf{FLAGS=MYDRIVER_ALL_INFO, LEVEL=TRACE_LEVEL_INFORMATION}(MSG, ...);
+// end_wpp

--- a/ZFSin/ZFSin.vcxproj
+++ b/ZFSin/ZFSin.vcxproj
@@ -156,7 +156,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)/ZFSin/spl/include;$(SolutionDir)/ZFSin/zfs/include;$(SolutionDir)/ZFSin/zfs/module/icp/include;$(SolutionDir)/ZFSin/zfs/lib/zlib-1.2.3;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/ZFSin;$(SolutionDir)/ZFSin/spl/include;$(SolutionDir)/ZFSin/zfs/include;$(SolutionDir)/ZFSin/zfs/module/icp/include;$(SolutionDir)/ZFSin/zfs/lib/zlib-1.2.3;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_KERNEL;__x86_64__;_LP64;%(PreprocessorDefinitions);Z_PREFIX;MY_ZCALLOC</PreprocessorDefinitions>
       <TreatWarningAsError>false</TreatWarningAsError>
       <WarningLevel>Level3</WarningLevel>
@@ -164,6 +164,20 @@
       <RuntimeLibrary>
       </RuntimeLibrary>
       <DisableSpecificWarnings>4018;4100;4146;4152;4200;4201;4204;4210;4211;4242;4244;4389;4706;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <WppEnabled>false</WppEnabled>
+      <WppAdditionalIncludeDirectories>$(SolutionDir)\ZFSin\spl\include;$(SolutionDir)\ZFSin\zfs\include;$(SolutionDir)\ZFSin\zfs\module/icp/include;$(SolutionDir)\ZFSin\zfs\lib\zlib-1.2.3;</WppAdditionalIncludeDirectories>
+      <WppGenerateUsingTemplateFile>
+      </WppGenerateUsingTemplateFile>
+      <WppScanConfigurationData>
+      </WppScanConfigurationData>
+      <PreprocessToFile>false</PreprocessToFile>
+      <WppTraceFunction>
+      </WppTraceFunction>
+      <ForcedUsingFiles>
+      </ForcedUsingFiles>
+      <ForcedIncludeFiles>$(KIT_SHARED_IncludePath)\warning.h; </ForcedIncludeFiles>
+      <WppPreprocessorDefinitions>
+      </WppPreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>wdmsec.lib;Storport.lib;scsiwmi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -174,14 +188,24 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)/ZFSin/spl/include;$(SolutionDir)/ZFSin/zfs/include;$(SolutionDir)/ZFSin/zfs/module/icp/include;$(SolutionDir)/ZFSin/zfs/lib/zlib-1.2.3;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_KERNEL;__x86_64__;_LP64;%(PreprocessorDefinitions);Z_PREFIX;MY_ZCALLOC</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)\ZFSin;$(SolutionDir)\ZFSin\$(Platform)\$(ConfigurationName);$(SolutionDir)/ZFSin/spl/include;$(SolutionDir)/ZFSin/zfs/include;$(SolutionDir)/ZFSin/zfs/module/icp/include;$(SolutionDir)/ZFSin/zfs/lib/zlib-1.2.3;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>RUN_WPP;_KERNEL;__x86_64__;_LP64;%(PreprocessorDefinitions);Z_PREFIX;MY_ZCALLOC</PreprocessorDefinitions>
       <TreatWarningAsError>false</TreatWarningAsError>
       <WarningLevel>Level3</WarningLevel>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <RuntimeLibrary>
       </RuntimeLibrary>
       <DisableSpecificWarnings>4018;4100;4146;4152;4200;4201;4204;4210;4211;4242;4244;4389;4706;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <PreprocessToFile>false</PreprocessToFile>
+      <WppAdditionalIncludeDirectories>$(SolutionDir)\ZFSin\spl\include;$(SolutionDir)\ZFSin\zfs\include;$(SolutionDir)\ZFSin\zfs\module/icp/include;$(SolutionDir)\ZFSin\zfs\lib\zlib-1.2.3;</WppAdditionalIncludeDirectories>
+      <WppEnabled>true</WppEnabled>
+      <WppTraceFunction>dprintf{FLAGS=MYDRIVER_ALL_INFO, LEVEL=TRACE_LEVEL_INFORMATION}(MSG, ...);</WppTraceFunction>
+      <WppPreprocessorDefinitions>WPP_INLINE __inline</WppPreprocessorDefinitions>
+      <ForcedUsingFiles>
+      </ForcedUsingFiles>
+      <ForcedIncludeFiles>$(KIT_SHARED_IncludePath)\warning.h; </ForcedIncludeFiles>
+      <WppScanConfigurationData>$(KMDF_INC_PATH)$(KMDF_VER_PATH)\WdfTraceEnums.h</WppScanConfigurationData>
+      <WppGenerateUsingTemplateFile>{km-default.tpl}*.tmh</WppGenerateUsingTemplateFile>
     </ClCompile>
     <Link>
       <AdditionalDependencies>wdmsec.lib;Storport.lib;scsiwmi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -364,7 +388,6 @@
     <ClCompile Include="zfs\module\zfs\dsl_destroy.c" />
     <ClCompile Include="zfs\module\zfs\dsl_dir.c" />
     <ClCompile Include="zfs\module\zfs\dsl_pool.c" />
-    <ClCompile Include="zfs\module\zfs\dsl_proc.c" />
     <ClCompile Include="zfs\module\zfs\dsl_prop.c" />
     <ClCompile Include="zfs\module\zfs\dsl_scan.c" />
     <ClCompile Include="zfs\module\zfs\dsl_synctask.c" />

--- a/ZFSin/ZFSin.vcxproj.filters
+++ b/ZFSin/ZFSin.vcxproj.filters
@@ -387,9 +387,6 @@
     <ClCompile Include="zfs\module\zfs\dsl_pool.c">
       <Filter>Source Files\ZFS\module\zfs</Filter>
     </ClCompile>
-    <ClCompile Include="zfs\module\zfs\dsl_proc.c">
-      <Filter>Source Files\ZFS\module\zfs</Filter>
-    </ClCompile>
     <ClCompile Include="zfs\module\zfs\dsl_prop.c">
       <Filter>Source Files\ZFS\module\zfs</Filter>
     </ClCompile>

--- a/ZFSin/driver.c
+++ b/ZFSin/driver.c
@@ -7,6 +7,11 @@
 
 #include <sys/wzvol.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "driver.tmh"
+#endif
+
 DRIVER_INITIALIZE DriverEntry;
 //EVT_WDF_DRIVER_DEVICE_ADD ZFSin_Init;
 
@@ -43,6 +48,9 @@ void ZFSin_Fini(PDRIVER_OBJECT  DriverObject)
 		ExFreePoolWithTag(STOR_wzvolDriverInfo.zvContextArray, MP_TAG_GENERAL);
 		STOR_wzvolDriverInfo.zvContextArray = NULL;
 	}
+#ifdef RUN_WPP
+	WPP_CLEANUP(DriverObject);
+#endif
 }
 
 /*
@@ -51,7 +59,11 @@ void ZFSin_Fini(PDRIVER_OBJECT  DriverObject)
 NTSTATUS DriverEntry(_In_ PDRIVER_OBJECT  DriverObject, _In_ PUNICODE_STRING pRegistryPath)
 {
 	NTSTATUS status;
-
+#ifdef RUN_WPP
+	WPP_INIT_TRACING(DriverObject, pRegistryPath);
+#endif
+	dprintf("\nEntering %s", __func__);
+	
 	KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL, "ZFSin: DriverEntry\n"));
 
 	// Setup global so zfs_ioctl.c can setup devnode

--- a/ZFSin/spl/include/sys/debug.h
+++ b/ZFSin/spl/include/sys/debug.h
@@ -96,7 +96,7 @@ extern void printBuffer(const char *fmt, ...);
 	#define IOLog(...)
 	#define PANIC(fmt, ...)						\
 	do {									\
-		dprintf(fmt, __VA_ARGS__); \
+		xprintf(fmt, __VA_ARGS__); \
 	} while (0)
 #endif
 

--- a/ZFSin/spl/module/spl/spl-err.c
+++ b/ZFSin/spl/module/spl/spl-err.c
@@ -29,6 +29,12 @@
 #include <sys/cmn_err.h>
 #include <spl-debug.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-err.tmh"
+#endif
+
+
 
 void
 vcmn_err(int ce, const char *fmt, va_list ap)

--- a/ZFSin/spl/module/spl/spl-kmem.c
+++ b/ZFSin/spl/module/spl/spl-kmem.c
@@ -45,6 +45,11 @@
 #include <sys/callb.h>
 //#include <stdbool.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-kmem.tmh"
+#endif
+
 // ===============================================================
 // Options
 // ===============================================================
@@ -1020,6 +1025,7 @@ kmem_error(int error, kmem_cache_t *cparg, void *bufarg)
 			   (void *)sp, cp->cache_name);
 
 //#include <../um/DbgHelp.h>
+
 //#pragma comment(lib, "Dbghelp.lib")
 //		HANDLE         process;
 //		process = GetCurrentProcess();
@@ -4941,7 +4947,7 @@ spl_event_thread(void *notused)
 	HANDLE low_mem_handle;
 	low_mem_event = IoCreateNotificationEvent((PUNICODE_STRING)&low_mem_name, &low_mem_handle);
 	if (low_mem_event == NULL) {
-		dprintf("%s: failed IoCreateNotificationEvent(\\KernelObjects\\LowMemoryCondition)");
+		dprintf("%s: failed IoCreateNotificationEvent(\\KernelObjects\\LowMemoryCondition)", __func__);
 		thread_exit();
 	}
 	KeClearEvent(low_mem_event);

--- a/ZFSin/spl/module/spl/spl-kobj.c
+++ b/ZFSin/spl/module/spl/spl-kobj.c
@@ -31,6 +31,12 @@
 //#include <sys/malloc.h>
 //#include <libkern/libkern.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-kobj.tmh"
+#endif
+
+
 struct _buf *
 kobj_open_file(char *name)
 {

--- a/ZFSin/spl/module/spl/spl-kstat.c
+++ b/ZFSin/spl/module/spl/spl-kstat.c
@@ -77,6 +77,11 @@
 #include <vm/anon.h>
 #include <vm/seg_kmem.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-kstat.tmh"
+#endif
+
 /*
 * Global lock to protect the AVL trees and kstat_chain_id.
 */
@@ -1247,6 +1252,7 @@ kstat_timer_stop(kstat_timer_t *ktp)
 #include <sys/atomic.h>
 #include <sys/policy.h>
 #include <sys/zone.h>
+
 
 static dev_info_t *kstat_devi;
 

--- a/ZFSin/spl/module/spl/spl-seg_kmem.c
+++ b/ZFSin/spl/module/spl/spl-seg_kmem.c
@@ -94,6 +94,12 @@
 #ifdef _KERNEL
 #define XNU_KERNEL_PRIVATE
 //#include <mach/vm_types.h>
+
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-seg_kmem.tmh"
+#endif
+
 //extern vm_map_t kernel_map;
 
 /*

--- a/ZFSin/spl/module/spl/spl-taskq.c
+++ b/ZFSin/spl/module/spl/spl-taskq.c
@@ -502,6 +502,12 @@
 #include <sys/sysdc.h>
 #include <sys/note.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-taskq.tmh"
+#endif
+
+
 static kmem_cache_t *taskq_ent_cache, *taskq_cache;
 
 /*

--- a/ZFSin/spl/module/spl/spl-thread.c
+++ b/ZFSin/spl/module/spl/spl-thread.c
@@ -36,6 +36,12 @@
 
 #include <ntddk.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-thread.tmh"
+#endif
+
+
 uint64_t zfs_threads = 0;
 
 kthread_t *

--- a/ZFSin/spl/module/spl/spl-tsd.c
+++ b/ZFSin/spl/module/spl/spl-tsd.c
@@ -58,6 +58,12 @@
 #include <sys/avl.h>
 #include <spl-debug.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-tsd.tmh"
+#endif
+
+
 /* Initial size of array, and realloc growth size */
 #define TSD_ALLOC_SIZE 5
 

--- a/ZFSin/spl/module/spl/spl-vmem.c
+++ b/ZFSin/spl/module/spl/spl-vmem.c
@@ -224,6 +224,12 @@
 //#include <sys/panic.h>
 //#include <stdbool.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-vmem.tmh"
+#endif
+
+
 #define	VMEM_INITIAL		21	/* early vmem arenas */
 #define	VMEM_SEG_INITIAL	800
 //200 //400	/* early segments */

--- a/ZFSin/spl/module/spl/spl-vnode.c
+++ b/ZFSin/spl/module/spl/spl-vnode.c
@@ -41,6 +41,10 @@
 #include <sys/zfs_znode.h>
 #endif
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-vnode.tmh"
+#endif
 
 //#define FIND_MAF
 
@@ -603,6 +607,7 @@ void spl_vnode_fini(void)
 }
 
 #include <sys/file.h>
+
 struct fileproc;
 
 extern int fp_drop(struct proc *p, int fd, struct fileproc *fp, int locked);
@@ -1360,7 +1365,7 @@ int vnode_drain_delayclose(int force)
 			(vp->SectionObjectPointers.ImageSectionObject == NULL) &&
 			(vp->SectionObjectPointers.DataSectionObject == NULL)) {
 			// We are ready to let go
-			dprintf("%s: drain %vp\n", __func__, vp);
+			dprintf("%s: drain %p\n", __func__, vp);
 
 			// Pass VNODELOCKED as we hold vp, recycle will unlock.
 			// We have to give up all_list due to recycle -> reclaim -> rmnode -> purgedir -> zget -> vnode_create

--- a/ZFSin/spl/module/spl/spl-windows.c
+++ b/ZFSin/spl/module/spl/spl-windows.c
@@ -69,6 +69,12 @@ uint64_t spl_GetPhysMem(void);
 #define	_task_user_
 //#include <IOKit/IOLib.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-windows.tmh"
+#endif
+
+
 
 // Size in bytes of the memory allocated in seg_kmem
 extern uint64_t		segkmem_total_mem_allocated;

--- a/ZFSin/spl/module/spl/spl-xdr.c
+++ b/ZFSin/spl/module/spl/spl-xdr.c
@@ -32,6 +32,12 @@
 #include <spl-debug.h>
 #include <sys/byteorder.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spl-xdr.tmh"
+#endif
+
+
 
 /*
  * SPL's XDR mem implementation.

--- a/ZFSin/zfs/include/sys/zfs_znode.h
+++ b/ZFSin/zfs/include/sys/zfs_znode.h
@@ -281,6 +281,7 @@ typedef struct znode {
  * ZFS_EXIT() must be called before exitting the vop.
  * ZFS_VERIFY_ZP() verifies the znode is valid.
  */
+#ifdef DBG
 #define ZFS_ENTER(zfsvfs)                       \
     {                                                                   \
 		if (!POINTER_IS_VALID(zfsvfs)) {								\
@@ -293,6 +294,18 @@ typedef struct znode {
             return (EIO);                                               \
         }                                                               \
     }
+#else
+#define ZFS_ENTER(zfsvfs)                       \
+    {                                                                   \
+		if (!POINTER_IS_VALID(zfsvfs)) {								\
+			return EIO; }												\
+		rrm_enter_read(&(zfsvfs)->z_teardown_lock, FTAG);				\
+        if ((zfsvfs)->z_unmounted) {                                    \
+            ZFS_EXIT(zfsvfs);                                           \
+            return (EIO);                                               \
+        }                                                               \
+    }
+#endif
 
 #define ZFS_ENTER_NOERROR(zfsvfs)                                       \
 	rrm_enter_read(&(zfsvfs)->z_teardown_lock, FTAG)

--- a/ZFSin/zfs/lib/libzpool/libzpool/libzpool.vcxproj
+++ b/ZFSin/zfs/lib/libzpool/libzpool/libzpool.vcxproj
@@ -102,7 +102,6 @@
     <ClCompile Include="..\..\..\module\zfs\dsl_destroy.c" />
     <ClCompile Include="..\..\..\module\zfs\dsl_dir.c" />
     <ClCompile Include="..\..\..\module\zfs\dsl_pool.c" />
-    <ClCompile Include="..\..\..\module\zfs\dsl_proc.c" />
     <ClCompile Include="..\..\..\module\zfs\dsl_prop.c" />
     <ClCompile Include="..\..\..\module\zfs\dsl_scan.c" />
     <ClCompile Include="..\..\..\module\zfs\dsl_synctask.c" />

--- a/ZFSin/zfs/module/zfs/dbuf.c
+++ b/ZFSin/zfs/module/zfs/dbuf.c
@@ -51,6 +51,12 @@
 #include <sys/cityhash.h>
 #include <sys/spa_impl.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "dbuf.tmh"
+#endif
+
+
 uint_t zfs_dbuf_evict_key;
 
 //

--- a/ZFSin/zfs/module/zfs/dmu_objset.c
+++ b/ZFSin/zfs/module/zfs/dmu_objset.c
@@ -60,6 +60,12 @@
 #include <sys/dmu_recv.h>
 #include "zfs_namecheck.h"
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "dmu_objset.tmh"
+#endif
+
+
 /*
  * Needed to close a window in dnode_move() that allows the objset to be freed
  * before it can be safely accessed.

--- a/ZFSin/zfs/module/zfs/dmu_recv.c
+++ b/ZFSin/zfs/module/zfs/dmu_recv.c
@@ -60,6 +60,12 @@
 #include <sys/zvol.h>
 #include <sys/policy.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "dmu_recv.tmh"
+#endif
+
+
 int zfs_recv_queue_length = SPA_MAXBLOCKSIZE;
 
 static char *dmu_recv_tag = "dmu_recv_tag";

--- a/ZFSin/zfs/module/zfs/dmu_tx.c
+++ b/ZFSin/zfs/module/zfs/dmu_tx.c
@@ -40,6 +40,12 @@
 #include <sys/varargs.h>
 #include <sys/trace_dmu.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "dmu_tx.tmh"
+#endif
+
+
 typedef void (*dmu_tx_hold_func_t)(dmu_tx_t *tx, struct dnode *dn,
     uint64_t arg1, uint64_t arg2);
 

--- a/ZFSin/zfs/module/zfs/dnode.c
+++ b/ZFSin/zfs/module/zfs/dnode.c
@@ -39,6 +39,12 @@
 #include <sys/range_tree.h>
 #include <sys/trace_dnode.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "dnode.tmh"
+#endif
+
+
 dnode_stats_t dnode_stats = {
 	{ "dnode_hold_dbuf_hold",		KSTAT_DATA_UINT64 },
 	{ "dnode_hold_dbuf_read",		KSTAT_DATA_UINT64 },

--- a/ZFSin/zfs/module/zfs/dnode_sync.c
+++ b/ZFSin/zfs/module/zfs/dnode_sync.c
@@ -37,6 +37,12 @@
 #include <sys/range_tree.h>
 #include <sys/zfeature.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "dnode_sync.tmh"
+#endif
+
+
 static void
 dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 {

--- a/ZFSin/zfs/module/zfs/dsl_dataset.c
+++ b/ZFSin/zfs/module/zfs/dsl_dataset.c
@@ -62,6 +62,12 @@
 #include <sys/dmu_send.h>
 #include <sys/zio_checksum.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "dsl_dataset.tmh"
+#endif
+
+
 /*
  * The SPA supports block sizes up to 16MB.  However, very large blocks
  * can have an impact on i/o latency (e.g. tying up a spinning disk for

--- a/ZFSin/zfs/module/zfs/dsl_deleg.c
+++ b/ZFSin/zfs/module/zfs/dsl_deleg.c
@@ -82,6 +82,12 @@
 
 #include "zfs_deleg.h"
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "dsl_deleg.tmh"
+#endif
+
+
 /*
  * Validate that user is allowed to delegate specified permissions.
  *

--- a/ZFSin/zfs/module/zfs/dsl_dir.c
+++ b/ZFSin/zfs/module/zfs/dsl_dir.c
@@ -52,6 +52,12 @@
 #include "zfs_namecheck.h"
 #include "zfs_prop.h"
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "dsl_dir.tmh"
+#endif
+
+
 /*
  * Filesystem and Snapshot Limits
  * ------------------------------

--- a/ZFSin/zfs/module/zfs/dsl_pool.c
+++ b/ZFSin/zfs/module/zfs/dsl_pool.c
@@ -52,6 +52,12 @@
 #include <sys/trace_txg.h>
 #include <sys/mmp.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "dsl_pool.tmh"
+#endif
+
+
 /*
  * ZFS Write Throttle
  * ------------------

--- a/ZFSin/zfs/module/zfs/dsl_scan.c
+++ b/ZFSin/zfs/module/zfs/dsl_scan.c
@@ -54,6 +54,12 @@
 #include <sys/range_tree.h>
 #ifdef _KERNEL
 #include <sys/zfs_vfsops.h>
+
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "dsl_scan.tmh"
+#endif
+
 #endif
 
 /*

--- a/ZFSin/zfs/module/zfs/fm.c
+++ b/ZFSin/zfs/module/zfs/fm.c
@@ -76,6 +76,12 @@
 #include <sys/time.h>
 #include <sys/zfs_ioctl.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "fm.tmh"
+#endif
+
+
 int zfs_zevent_len_max = 0;
 int zfs_zevent_cols = 80;
 int zfs_zevent_console = 0;

--- a/ZFSin/zfs/module/zfs/mmp.c
+++ b/ZFSin/zfs/module/zfs/mmp.c
@@ -33,6 +33,12 @@
 #include <sys/callb.h>
 #include <sys/time.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "mmp.tmh"
+#endif
+
+
 /*
  * Multi-Modifier Protection (MMP) attempts to prevent a user from importing
  * or opening a pool on more than one host at a time.  In particular, it

--- a/ZFSin/zfs/module/zfs/range_tree.c
+++ b/ZFSin/zfs/module/zfs/range_tree.c
@@ -33,6 +33,12 @@
 #include <sys/zio.h>
 #include <sys/range_tree.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "range_tree.tmh"
+#endif
+
+
 /*
  * Range trees are tree-based data structures that can be used to
  * track free space or generally any space allocation information.

--- a/ZFSin/zfs/module/zfs/sa.c
+++ b/ZFSin/zfs/module/zfs/sa.c
@@ -45,6 +45,12 @@
 #include <sys/errno.h>
 #include <sys/zfs_context.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "sa.tmh"
+#endif
+
+
 /*
  * ZFS System attributes:
  *

--- a/ZFSin/zfs/module/zfs/spa_misc.c
+++ b/ZFSin/zfs/module/zfs/spa_misc.c
@@ -61,6 +61,12 @@
 #include "zfs_prop.h"
 #include <sys/zfeature.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "spa_misc.tmh"
+#endif
+
+
 /*
  * SPA locking
  *

--- a/ZFSin/zfs/module/zfs/txg.c
+++ b/ZFSin/zfs/module/zfs/txg.c
@@ -34,6 +34,12 @@
 #include <sys/callb.h>
 #include <sys/trace_txg.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "txg.tmh"
+#endif
+
+
 //#define dprintf printf
 #undef dprintf
 #define dprintf

--- a/ZFSin/zfs/module/zfs/vdev_disk.c
+++ b/ZFSin/zfs/module/zfs/vdev_disk.c
@@ -33,6 +33,12 @@
 #include <ntdddisk.h>
 #include <Ntddstor.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "vdev_disk.tmh"
+#endif
+
+
 
 /*
  * Virtual device vector for disks.

--- a/ZFSin/zfs/module/zfs/vdev_file.c
+++ b/ZFSin/zfs/module/zfs/vdev_file.c
@@ -34,6 +34,12 @@
 #include <sys/fm/fs/zfs.h>
 #include <sys/vnode.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "vdev_file.tmh"
+#endif
+
+
 /*
  * Virtual device vector for files.
  */

--- a/ZFSin/zfs/module/zfs/zap.c
+++ b/ZFSin/zfs/module/zfs/zap.c
@@ -49,6 +49,12 @@
 #include <sys/zap_impl.h>
 #include <sys/zap_leaf.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zap.tmh"
+#endif
+
+
 int fzap_default_block_shift = 14; /* 16k blocksize */
 
 extern inline zap_phys_t *zap_f_phys(zap_t *zap);

--- a/ZFSin/zfs/module/zfs/zap_leaf.c
+++ b/ZFSin/zfs/module/zfs/zap_leaf.c
@@ -40,6 +40,12 @@
 #include <sys/zap_leaf.h>
 #include <sys/arc.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zap_leaf.tmh"
+#endif
+
+
 static uint16_t *zap_leaf_rehash_entry(zap_leaf_t *l, uint16_t entry);
 
 #define	CHAIN_END 0xffff /* end of the chunk chain */

--- a/ZFSin/zfs/module/zfs/zap_micro.c
+++ b/ZFSin/zfs/module/zfs/zap_micro.c
@@ -40,6 +40,12 @@
 
 #ifdef _KERNEL
 #include <sys/sunddi.h>
+
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zap_micro.tmh"
+#endif
+
 #endif
 
 extern inline mzap_phys_t *zap_m_phys(zap_t *zap);

--- a/ZFSin/zfs/module/zfs/zfs_acl.c
+++ b/ZFSin/zfs/module/zfs/zfs_acl.c
@@ -53,6 +53,12 @@
 #include <sys/sa.h>
 //#include <acl/acl_common.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zfs_acl.tmh"
+#endif
+
+
 #define	ALLOW	ACE_ACCESS_ALLOWED_ACE_TYPE
 #define	DENY	ACE_ACCESS_DENIED_ACE_TYPE
 #define	MAX_ACE_TYPE	ACE_SYSTEM_ALARM_CALLBACK_OBJECT_ACE_TYPE

--- a/ZFSin/zfs/module/zfs/zfs_debug.c
+++ b/ZFSin/zfs/module/zfs/zfs_debug.c
@@ -25,6 +25,12 @@
 
 #include <sys/zfs_context.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zfs_debug.tmh"
+#endif
+
+
 #if !defined(_KERNEL) || !defined(__linux__)
 list_t zfs_dbgmsgs;
 int zfs_dbgmsg_size;

--- a/ZFSin/zfs/module/zfs/zfs_dir.c
+++ b/ZFSin/zfs/module/zfs/zfs_dir.c
@@ -59,6 +59,12 @@
 #include <sys/dnlc.h>
 #include <sys/extdirent.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zfs_dir.tmh"
+#endif
+
+
 /*
  * zfs_match_find() is used by zfs_dirent_lock() to peform zap lookups
  * of names after deciding which is the appropriate lookup interface.

--- a/ZFSin/zfs/module/zfs/zfs_ioctl.c
+++ b/ZFSin/zfs/module/zfs/zfs_ioctl.c
@@ -232,6 +232,11 @@
 #include <sys/lua/lua.h>
 #include <sys/lua/lauxlib.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zfs_ioctl.tmh"
+#endif
+
 /*
  * Limit maximum nvlist size.  We don't want users passing in insane values
  * for zc->zc_nvlist_src_size, since we will need to allocate that much memory.
@@ -7825,12 +7830,13 @@ VOID  DriverNotificationRoutine(
 		dprintf("Filesystem %p: '%wZ'\n", DeviceObject, name_info);
 	}
 	else {
-		dprintf("Filesystem %p: '%wZ'\n", DeviceObject, DeviceObject->DriverObject->DriverName);
+		dprintf("Filesystem %p: '%wZ'\n", DeviceObject, &DeviceObject->DriverObject->DriverName);
 	}
 }
 
 
 #include <Wdmsec.h>
+
 static int
 zfs_attach(void)
 {
@@ -7864,7 +7870,7 @@ zfs_attach(void)
 		&ioctlDeviceObject);                // Returned ptr to Device Object
 
 	if (!NT_SUCCESS(ntStatus)) {
-		dprintf(("ZFS: Couldn't create the device object /dev/zfs (%wZ)\n", ZFS_DEV_KERNEL));
+		dprintf("ZFS: Couldn't create the device object /dev/zfs (%wZ)\n", ZFS_DEV_KERNEL);
 		return ntStatus;
 	}
 	dprintf("ZFS: created kernel device node: %p: name %wZ\n", ioctlDeviceObject, ZFS_DEV_KERNEL);
@@ -7910,7 +7916,7 @@ zfs_attach(void)
 		&ntWin32NameString, &ntUnicodeString);
 
 	if (!NT_SUCCESS(ntStatus)) {
-		dprintf(("ZFS: Couldn't create userland symbolic link to /dev/zfs (%wZ)\n", ZFS_DEV));
+		dprintf("ZFS: Couldn't create userland symbolic link to /dev/zfs (%wZ)\n", ZFS_DEV);
 		IoDeleteDevice(ioctlDeviceObject);
 		return -1;
 	}

--- a/ZFSin/zfs/module/zfs/zfs_vfsops.c
+++ b/ZFSin/zfs/module/zfs/zfs_vfsops.c
@@ -103,6 +103,12 @@
 #include <sys/zfs_vnops.h>
 #include <sys/systeminfo.h>
 #include <sys/zfs_mount.h>
+
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zfs_vfsops.tmh"
+#endif
+
 #endif /* _WIN32 */
 
 //#define dprintf kprintf

--- a/ZFSin/zfs/module/zfs/zfs_vnops.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops.c
@@ -86,6 +86,12 @@
 #include <sys/zfs_vfsops.h>
 #include <sys/vnode.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zfs_vnops.tmh"
+#endif
+
+
 //#define dprintf printf
 
 int zfs_vnop_force_formd_normalized_output = 0; /* disabled by default */
@@ -2816,9 +2822,9 @@ zfs_readdir(vnode_t *vp, uio_t *uio, cred_t *cr, zfs_dirlist_t *zccb, int flags,
 					skip_this_entry = 1;
 			}
 #if 0
-			dprintf("comparing names '%.*S' == '%.*S' skip %d\n",
-				thisname.Length / sizeof(WCHAR), thisname.Buffer,
-				zccb->searchname.Length / sizeof(WCHAR), zccb->searchname.Buffer,
+			dprintf("comparing names '%S' (of length %u) == '%S' (of length %u) skip %d\n",
+				thisname.Buffer, thisname.Length / sizeof(WCHAR),
+				zccb->searchname.Buffer, zccb->searchname.Length / sizeof(WCHAR),
 				skip_this_entry);
 #endif
 			}
@@ -3028,8 +3034,8 @@ zfs_readdir(vnode_t *vp, uio_t *uio, cred_t *cr, zfs_dirlist_t *zccb, int flags,
 				error = RtlUTF8ToUnicodeN(nameptr, namelenholder, &namelenholder2, zap.za_name, namelen);
 				ASSERT(namelenholder == namelenholder2);
 #if 0
-				dprintf("%s: '%.*S' -> '%s' (namelen %d bytes: structsize %d)\n", __func__,
-					namelenholder / sizeof(WCHAR), nameptr, zap.za_name, namelenholder, structsize);
+				dprintf("%s: '%S of length %u' -> '%s' (namelen %d bytes: structsize %d)\n", __func__,
+					nameptr, namelenholder / sizeof(WCHAR), zap.za_name, namelenholder, structsize);
 #endif
 
 				// If we aren't to skip, advance all pointers

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
@@ -30,6 +30,12 @@
 #include <wdf.h>
 #include <sys/wzvol.h>
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zfs_windows_zvol.tmh"
+#endif
+
+
 extern PDRIVER_OBJECT WIN_DriverObject;
 static pHW_HBA_EXT STOR_HBAExt = NULL;
 
@@ -656,9 +662,9 @@ wzvol_HwStartIo(
 	NTSTATUS                  status;
 	UCHAR                     Result = ResultDone;
 
-	dprintf(
-		"MpHwStartIo:  SCSI Request Block = %!SRB!\n",
-		pSrb);
+	//dprintf(
+	//	"MpHwStartIo:  SCSI Request Block = %!SRB!\n",
+	//	pSrb);
 
 	_InterlockedExchangeAdd((volatile LONG *)&pHBAExt->SRBsSeen, 1);   // Bump count of SRBs encountered.
 

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
@@ -62,6 +62,12 @@
 //#undef dprintf
 //#define dprintf
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zfs_windows_zvol_scsi.tmh"
+#endif
+
+
 /*
  * We have a list of ZVOLs, and we receive incoming (Target, Lun) requests that needs to be mapped
  * to the correct "zv" ptr.

--- a/ZFSin/zfs/module/zfs/zfs_znode.c
+++ b/ZFSin/zfs/module/zfs/zfs_znode.c
@@ -71,6 +71,11 @@
 #include "zfs_prop.h"
 #include "zfs_comutil.h"
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zfs_znode.tmh"
+#endif
+
 /* Used by fstat(1). */
 #ifndef _WIN32
 SYSCTL_INT(_debug_sizeof, OID_AUTO, znode, CTLFLAG_RD, 0, sizeof (znode_t),
@@ -872,6 +877,7 @@ zfs_znode_alloc(zfsvfs_t *zfsvfs, dmu_buf_t *db, int blksz,
 
 #include <sys/dbuf.h>
 
+
 		dmu_buf_impl_t *db2 = (dmu_buf_impl_t *)db;
 		zbookmark_phys_t zb;
 
@@ -1560,7 +1566,7 @@ zfs_rezget(znode_t *zp)
 	}
 	mutex_exit(&zp->z_acl_lock);
 
-	dprintf("rezget: %p %p %p\n", zp, zp->z_xattr_lock,
+	dprintf("rezget: %p %p %p\n", zp, &zp->z_xattr_lock,
 	    zp->z_xattr_parent);
 
 	rw_enter(&zp->z_xattr_lock, RW_WRITER);

--- a/ZFSin/zfs/module/zfs/zvol.c
+++ b/ZFSin/zfs/module/zfs/zvol.c
@@ -90,6 +90,12 @@
 
 #include "zfs_namecheck.h"
 
+#ifdef RUN_WPP
+#include "Trace.h"
+#include "zvol.tmh"
+#endif
+
+
 uint64_t zvol_inhibit_dev = 0;
 dev_info_t zfs_dip_real = { 0 };
 dev_info_t *zfs_dip = &zfs_dip_real;


### PR DESCRIPTION
WPP is enabled only on Release build.

dprintf call, which is predominantly used to log message is used to generate the trace logs.

There are also few compilation error fix like variable length format specifier like "%.*s" and "%.*S"
