### PR TITLE
Enable WPP tracing in ZFSin project

### DIFF
--- a/ZFSin/CMakeLists.txt
+++ b/ZFSin/CMakeLists.txt
@@ -109,6 +109,7 @@ add_subdirectory(zfs)
 wdk_add_driver(ZFSin
   debug.c
   driver.c
+  Wpp.c
 )
 
 target_link_libraries(ZFSin PRIVATE

--- a/ZFSin/Trace.h
+++ b/ZFSin/Trace.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#if !defined WPPFILE || !defined RUN_WPP    // To enable Wpp; Select Yes under Run Wpp Tracing in Project properties
+#undef WPPFILE                              // And define both RUN_WPP and WPPFILE="%(FileName).tmh" in C/C++ preprocessor
+#undef RUN_WPP                              // To disable Wpp; Select No under Run Wpp Tracing; undef RUN_WPP/WPPFILE in C/C++ preprocessor
+#endif
+
+static const int TRACE_FATAL = 1;
+static const int TRACE_ERROR = 2;
+static const int TRACE_WARNING = 3;
+static const int TRACE_INFO = 4;
+static const int TRACE_VERBOSE = 5;
+static const int TRACE_NOISY = 8;
+
+#if defined RUN_WPP && defined WPPFILE
+#define WPPNAME		ZFSinTraceGuid
+#define WPPGUID		c20c603c,afd4,467d,bf76,c0a4c10553df
+
+#define WPP_DEFINE_DEFAULT_BITS                                        \
+        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                              \
+        WPP_DEFINE_BIT(TRACE_KDPRINT)                                  \
+        WPP_DEFINE_BIT(DEFAULT_TRACE_LEVEL)
+
+#undef WPP_DEFINE_CONTROL_GUID	
+#define WPP_CONTROL_GUIDS \
+    WPP_DEFINE_CONTROL_GUID(WPPNAME,(WPPGUID), \
+        WPP_DEFINE_DEFAULT_BITS )
+
+#define WPP_FLAGS_LEVEL_LOGGER(Flags, level)                                  \
+    WPP_LEVEL_LOGGER(Flags)
+
+#define WPP_FLAGS_LEVEL_ENABLED(Flags, level)                                 \
+    (WPP_LEVEL_ENABLED(Flags) && \
+    WPP_CONTROL(WPP_BIT_ ## Flags).Level >= level)
+
+#define WPP_LEVEL_FLAGS_LOGGER(lvl,flags) \
+           WPP_LEVEL_LOGGER(flags)
+
+#define WPP_LEVEL_FLAGS_ENABLED(lvl, flags) \
+           (WPP_LEVEL_ENABLED(flags) && WPP_CONTROL(WPP_BIT_ ## flags).Level >= lvl)
+
+
+// begin_wpp config
+// FUNC dprintf{FLAGS=MYDRIVER_ALL_INFO, LEVEL=TRACE_INFO}(MSG, ...);
+// FUNC TraceEvent{FLAGS=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);
+// end_wpp
+
+#include WPPFILE
+
+#else
+
+#undef WPP_INIT_TRACING
+#define WPP_INIT_TRACING(...)	((void)(0, __VA_ARGS__))
+
+#undef WPP_CLEANUP
+#define WPP_CLEANUP(...)	((void)(0, __VA_ARGS__))
+#endif
+
+#ifndef WPP_CHECK_INIT
+#define WPP_CHECK_INIT
+#endif
+
+
+void ZFSWppInit(PDRIVER_OBJECT pDriverObject, PUNICODE_STRING pRegistryPath);
+
+void ZFSWppCleanup(PDRIVER_OBJECT pDriverObject);

--- a/ZFSin/Wpp.c
+++ b/ZFSin/Wpp.c
@@ -1,0 +1,14 @@
+#include <ntddk.h>
+#include <Trace.h>
+
+void
+ZFSWppInit(PDRIVER_OBJECT pDriverObject, PUNICODE_STRING pRegistryPath)
+{
+    WPP_INIT_TRACING(pDriverObject, pRegistryPath);
+}
+
+void
+ZFSWppCleanup(PDRIVER_OBJECT pDriverObject)
+{
+    WPP_CLEANUP(pDriverObject);
+}

--- a/ZFSin/ZFSin.vcxproj
+++ b/ZFSin/ZFSin.vcxproj
@@ -156,14 +156,20 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)/ZFSin/spl/include;$(SolutionDir)/ZFSin/zfs/include;$(SolutionDir)/ZFSin/zfs/module/icp/include;$(SolutionDir)/ZFSin/zfs/lib/zlib-1.2.3;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_KERNEL;__x86_64__;_LP64;%(PreprocessorDefinitions);Z_PREFIX;MY_ZCALLOC</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)\ZFSin;$(SolutionDir)/ZFSin/spl/include;$(SolutionDir)/ZFSin/zfs/include;$(SolutionDir)/ZFSin/zfs/module/icp/include;$(SolutionDir)/ZFSin/zfs/lib/zlib-1.2.3;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WPPFILE="%(Filename).tmh";_KERNEL;__x86_64__;_LP64;%(PreprocessorDefinitions);Z_PREFIX;MY_ZCALLOC</PreprocessorDefinitions>
       <TreatWarningAsError>false</TreatWarningAsError>
       <WarningLevel>Level3</WarningLevel>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <RuntimeLibrary>
       </RuntimeLibrary>
       <DisableSpecificWarnings>4018;4100;4146;4152;4200;4201;4204;4210;4211;4242;4244;4389;4706;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <WppEnabled>false</WppEnabled>
+      <WppTraceFunction>TraceEvent{FLAGS=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);dprintf{FLAGS=MYDRIVER_ALL_INFO, LEVEL=TRACE_INFO}(MSG, ...);</WppTraceFunction>
+      <WppGenerateUsingTemplateFile>{km-default.tpl}*.tmh</WppGenerateUsingTemplateFile>
+      <WppScanConfigurationData>$(KMDF_INC_PATH)$(KMDF_VER_PATH)\WdfTraceEnums.h</WppScanConfigurationData>
+      <WppPreprocessorDefinitions>WPP_INLINE __inline</WppPreprocessorDefinitions>
+      <UndefinePreprocessorDefinitions>RUN_WPP</UndefinePreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>wdmsec.lib;Storport.lib;scsiwmi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -174,14 +180,19 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)/ZFSin/spl/include;$(SolutionDir)/ZFSin/zfs/include;$(SolutionDir)/ZFSin/zfs/module/icp/include;$(SolutionDir)/ZFSin/zfs/lib/zlib-1.2.3;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_KERNEL;__x86_64__;_LP64;%(PreprocessorDefinitions);Z_PREFIX;MY_ZCALLOC</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)\ZFSin;$(SolutionDir)\$(Platform)\$(ConfigurationName)\;$(SolutionDir)\ZFSin;$(SolutionDir)\ZFSin\$(Platform)\$(ConfigurationName);$(SolutionDir)/ZFSin/spl/include;$(SolutionDir)/ZFSin/zfs/include;$(SolutionDir)/ZFSin/zfs/module/icp/include;$(SolutionDir)/ZFSin/zfs/lib/zlib-1.2.3;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>RUN_WPP;WPPFILE="%(Filename).tmh";_KERNEL;__x86_64__;_LP64;%(PreprocessorDefinitions);Z_PREFIX;MY_ZCALLOC</PreprocessorDefinitions>
       <TreatWarningAsError>false</TreatWarningAsError>
       <WarningLevel>Level3</WarningLevel>
       <StructMemberAlignment>8Bytes</StructMemberAlignment>
       <RuntimeLibrary>
       </RuntimeLibrary>
       <DisableSpecificWarnings>4018;4100;4146;4152;4200;4201;4204;4210;4211;4242;4244;4389;4706;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <WppEnabled>true</WppEnabled>
+      <WppTraceFunction>TraceEvent{FLAGS=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);dprintf{FLAGS=MYDRIVER_ALL_INFO, LEVEL=TRACE_INFO}(MSG, ...);</WppTraceFunction>
+      <WppPreprocessorDefinitions>WPP_INLINE __inline</WppPreprocessorDefinitions>
+      <WppScanConfigurationData>$(KMDF_INC_PATH)$(KMDF_VER_PATH)\WdfTraceEnums.h</WppScanConfigurationData>
+      <WppGenerateUsingTemplateFile>{km-default.tpl}*.tmh</WppGenerateUsingTemplateFile>
     </ClCompile>
     <Link>
       <AdditionalDependencies>wdmsec.lib;Storport.lib;scsiwmi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -249,6 +260,7 @@
     <ClCompile Include="spl\module\spl\spl-vnode.c" />
     <ClCompile Include="spl\module\spl\spl-windows.c" />
     <ClCompile Include="spl\module\spl\spl-xdr.c" />
+    <ClCompile Include="Wpp.c" />
     <ClCompile Include="zfs\lib\zlib-1.2.3\adler32.c" />
     <ClCompile Include="zfs\lib\zlib-1.2.3\compress.c" />
     <ClCompile Include="zfs\lib\zlib-1.2.3\contrib\masmx64\inffas8664.c" />
@@ -334,7 +346,12 @@
     <ClCompile Include="zfs\module\zcommon\zprop_common.c" />
     <ClCompile Include="zfs\module\zfs\abd.c" />
     <ClCompile Include="zfs\module\zfs\aggsum.c" />
-    <ClCompile Include="zfs\module\zfs\arc.c" />
+    <ClCompile Include="zfs\module\zfs\arc.c">
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+    </ClCompile>
     <ClCompile Include="zfs\module\zfs\blkptr.c" />
     <ClCompile Include="zfs\module\zfs\bplist.c" />
     <ClCompile Include="zfs\module\zfs\bpobj.c" />
@@ -364,7 +381,12 @@
     <ClCompile Include="zfs\module\zfs\dsl_destroy.c" />
     <ClCompile Include="zfs\module\zfs\dsl_dir.c" />
     <ClCompile Include="zfs\module\zfs\dsl_pool.c" />
-    <ClCompile Include="zfs\module\zfs\dsl_proc.c" />
+    <ClCompile Include="zfs\module\zfs\dsl_proc.c">
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+    </ClCompile>
     <ClCompile Include="zfs\module\zfs\dsl_prop.c" />
     <ClCompile Include="zfs\module\zfs\dsl_scan.c" />
     <ClCompile Include="zfs\module\zfs\dsl_synctask.c" />
@@ -423,29 +445,74 @@
     <ClCompile Include="zfs\module\zfs\zcp_synctask.c" />
     <ClCompile Include="zfs\module\zfs\zfeature.c" />
     <ClCompile Include="zfs\module\zfs\zfeature_common.c" />
-    <ClCompile Include="zfs\module\zfs\zfs_acl.c" />
+    <ClCompile Include="zfs\module\zfs\zfs_acl.c">
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+    </ClCompile>
     <ClCompile Include="zfs\module\zfs\zfs_byteswap.c" />
     <ClCompile Include="zfs\module\zfs\zfs_debug.c" />
     <ClCompile Include="zfs\module\zfs\zfs_dir.c" />
     <ClCompile Include="zfs\module\zfs\zfs_fm.c" />
     <ClCompile Include="zfs\module\zfs\zfs_fuid.c" />
-    <ClCompile Include="zfs\module\zfs\zfs_ioctl.c" />
+    <ClCompile Include="zfs\module\zfs\zfs_ioctl.c">
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+    </ClCompile>
     <ClCompile Include="zfs\module\zfs\zfs_kstat_windows.c" />
     <ClCompile Include="zfs\module\zfs\zfs_log.c" />
     <ClCompile Include="zfs\module\zfs\zfs_onexit.c" />
     <ClCompile Include="zfs\module\zfs\zfs_replay.c" />
     <ClCompile Include="zfs\module\zfs\zfs_rlock.c" />
     <ClCompile Include="zfs\module\zfs\zfs_sa.c" />
-    <ClCompile Include="zfs\module\zfs\zfs_vfsops.c" />
-    <ClCompile Include="zfs\module\zfs\zfs_vnops.c" />
-    <ClCompile Include="zfs\module\zfs\zfs_vnops_windows.c" />
-    <ClCompile Include="zfs\module\zfs\zfs_vnops_windows_lib.c" />
-    <ClCompile Include="zfs\module\zfs\zfs_vnops_windows_mount.c" />
+    <ClCompile Include="zfs\module\zfs\zfs_vfsops.c">
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+    </ClCompile>
+    <ClCompile Include="zfs\module\zfs\zfs_vnops.c">
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+    </ClCompile>
+    <ClCompile Include="zfs\module\zfs\zfs_vnops_windows.c">
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+    </ClCompile>
+    <ClCompile Include="zfs\module\zfs\zfs_vnops_windows_lib.c">
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+    </ClCompile>
+    <ClCompile Include="zfs\module\zfs\zfs_vnops_windows_mount.c">
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+    </ClCompile>
     <ClCompile Include="zfs\module\zfs\zfs_windows.c" />
-    <ClCompile Include="zfs\module\zfs\zfs_windows_zvol.c" />
+    <ClCompile Include="zfs\module\zfs\zfs_windows_zvol.c">
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+    </ClCompile>
     <ClCompile Include="zfs\module\zfs\zfs_windows_zvol_scsi.c" />
     <ClCompile Include="zfs\module\zfs\zfs_windows_zvol_wmi.c" />
-    <ClCompile Include="zfs\module\zfs\zfs_znode.c" />
+    <ClCompile Include="zfs\module\zfs\zfs_znode.c">
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+    </ClCompile>
     <ClCompile Include="zfs\module\zfs\zil.c" />
     <ClCompile Include="zfs\module\zfs\zio.c" />
     <ClCompile Include="zfs\module\zfs\zio_checksum.c" />

--- a/ZFSin/ZFSin.vcxproj.filters
+++ b/ZFSin/ZFSin.vcxproj.filters
@@ -807,6 +807,9 @@
     <ClCompile Include="zfs\module\zfs\zfs_vnops_windows_mount.c">
       <Filter>Source Files\ZFS\module\zfs</Filter>
     </ClCompile>
+    <ClCompile Include="Wpp.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="zfs\module\icp\algs\edonr\edonr_byteorder.h">

--- a/ZFSin/driver.c
+++ b/ZFSin/driver.c
@@ -7,6 +7,8 @@
 
 #include <sys/wzvol.h>
 
+#include "Trace.h"
+
 DRIVER_INITIALIZE DriverEntry;
 //EVT_WDF_DRIVER_DEVICE_ADD ZFSin_Init;
 
@@ -23,7 +25,6 @@ PDRIVER_UNLOAD STOR_DriverUnload;
 PDRIVER_DISPATCH STOR_MajorFunction[IRP_MJ_MAXIMUM_FUNCTION + 1];
 
 wzvolDriverInfo STOR_wzvolDriverInfo;
-
 
 DRIVER_UNLOAD ZFSin_Fini;
 void ZFSin_Fini(PDRIVER_OBJECT  DriverObject)
@@ -43,6 +44,7 @@ void ZFSin_Fini(PDRIVER_OBJECT  DriverObject)
 		ExFreePoolWithTag(STOR_wzvolDriverInfo.zvContextArray, MP_TAG_GENERAL);
 		STOR_wzvolDriverInfo.zvContextArray = NULL;
 	}
+	ZFSWppCleanup(DriverObject);
 }
 
 /*
@@ -51,7 +53,8 @@ void ZFSin_Fini(PDRIVER_OBJECT  DriverObject)
 NTSTATUS DriverEntry(_In_ PDRIVER_OBJECT  DriverObject, _In_ PUNICODE_STRING pRegistryPath)
 {
 	NTSTATUS status;
-
+	ZFSWppInit(DriverObject, pRegistryPath);
+	
 	KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL, "ZFSin: DriverEntry\n"));
 
 	// Setup global so zfs_ioctl.c can setup devnode

--- a/ZFSin/spl/include/sys/debug.h
+++ b/ZFSin/spl/include/sys/debug.h
@@ -72,18 +72,20 @@ extern void printBuffer(const char *fmt, ...);
 		#define dprintf(...) printBuffer(__VA_ARGS__)
 		#define IOLog(...) printBuffer(__VA_ARGS__)
 		#define xprintf(...) KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, __VA_ARGS__))
+		#define TraceEvent(x, ...) printBuffer(__VA_ARGS__)
 	#else
 		#undef KdPrintEx
 		#define KdPrintEx(_x_) DbgPrintEx _x_
 		#define dprintf(...) KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, __VA_ARGS__))
 		#define IOLog(...) KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, __VA_ARGS__))
 		#define xprintf(...) KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, __VA_ARGS__))
+		#define TraceEvent(level, ...) KdPrintEx((DPFLTR_IHVDRIVER_ID, level, __VA_ARGS__))
 		//#define dprintf(...)
 		//#define IOLog(...)
 	#endif
 		#define PANIC(fmt, ...)						\
 		do {									\
-			dprintf(fmt, __VA_ARGS__); \
+			xprintf(fmt, __VA_ARGS__); \
 			DbgBreakPoint(); \
 		} while (0)
 #else
@@ -91,12 +93,13 @@ extern void printBuffer(const char *fmt, ...);
 	//#define KdPrintEx(_x_) DbgPrintEx _x_
 	//#define dprintf(...) KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, __VA_ARGS__))
 	//#define IOLog(...) KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, __VA_ARGS__))
+    #define TraceEvent(x, ...)
 	#define xprintf(...) DbgPrintEx(DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, __VA_ARGS__)
 	#define dprintf(...)
 	#define IOLog(...)
 	#define PANIC(fmt, ...)						\
 	do {									\
-		dprintf(fmt, __VA_ARGS__); \
+		xprintf(fmt, __VA_ARGS__); \
 	} while (0)
 #endif
 

--- a/ZFSin/spl/module/spl/spl-err.c
+++ b/ZFSin/spl/module/spl/spl-err.c
@@ -29,6 +29,7 @@
 #include <sys/cmn_err.h>
 #include <spl-debug.h>
 
+#include <Trace.h>
 
 void
 vcmn_err(int ce, const char *fmt, va_list ap)
@@ -47,7 +48,7 @@ vcmn_err(int ce, const char *fmt, va_list ap)
 			dprintf("SPL: Notice: %s\n", msg);
 			break;
         case CE_WARN:
-			dprintf("SPL: Warning: %s\n", msg);
+			TraceEvent(TRACE_WARNING, "SPL: Warning: %s\n", msg);
 			break;
         case CE_PANIC:
 			PANIC("%s", msg);

--- a/ZFSin/spl/module/spl/spl-kobj.c
+++ b/ZFSin/spl/module/spl/spl-kobj.c
@@ -31,6 +31,8 @@
 //#include <sys/malloc.h>
 //#include <libkern/libkern.h>
 
+#include <Trace.h>
+
 struct _buf *
 kobj_open_file(char *name)
 {
@@ -44,7 +46,7 @@ kobj_open_file(char *name)
    // (void) vfs_context_rele(vctx);
 
     if (error) {
-        dprintf("kobj_open_file: \"%s\", err %d from vnode_open\n", name ? name : "", error);
+        TraceEvent(TRACE_ERROR, "kobj_open_file: \"%s\", err %d from vnode_open\n", name ? name : "", error);
 
         return ((struct _buf *)-1);
     }

--- a/ZFSin/spl/module/spl/spl-kstat.c
+++ b/ZFSin/spl/module/spl/spl-kstat.c
@@ -77,6 +77,8 @@
 #include <vm/anon.h>
 #include <vm/seg_kmem.h>
 
+#include <Trace.h>
+
 /*
 * Global lock to protect the AVL trees and kstat_chain_id.
 */

--- a/ZFSin/spl/module/spl/spl-seg_kmem.c
+++ b/ZFSin/spl/module/spl/spl-seg_kmem.c
@@ -94,6 +94,9 @@
 #ifdef _KERNEL
 #define XNU_KERNEL_PRIVATE
 //#include <mach/vm_types.h>
+
+#include <Trace.h>
+
 //extern vm_map_t kernel_map;
 
 /*

--- a/ZFSin/spl/module/spl/spl-taskq.c
+++ b/ZFSin/spl/module/spl/spl-taskq.c
@@ -502,6 +502,8 @@
 #include <sys/sysdc.h>
 #include <sys/note.h>
 
+#include <Trace.h>
+
 static kmem_cache_t *taskq_ent_cache, *taskq_cache;
 
 /*

--- a/ZFSin/spl/module/spl/spl-thread.c
+++ b/ZFSin/spl/module/spl/spl-thread.c
@@ -36,6 +36,8 @@
 
 #include <ntddk.h>
 
+#include <Trace.h>
+
 uint64_t zfs_threads = 0;
 
 kthread_t *

--- a/ZFSin/spl/module/spl/spl-tsd.c
+++ b/ZFSin/spl/module/spl/spl-tsd.c
@@ -58,6 +58,8 @@
 #include <sys/avl.h>
 #include <spl-debug.h>
 
+#include <Trace.h>
+
 /* Initial size of array, and realloc growth size */
 #define TSD_ALLOC_SIZE 5
 

--- a/ZFSin/spl/module/spl/spl-vmem.c
+++ b/ZFSin/spl/module/spl/spl-vmem.c
@@ -224,6 +224,8 @@
 //#include <sys/panic.h>
 //#include <stdbool.h>
 
+#include <Trace.h>
+
 #define	VMEM_INITIAL		21	/* early vmem arenas */
 #define	VMEM_SEG_INITIAL	800
 //200 //400	/* early segments */
@@ -611,8 +613,8 @@ vmem_freelist_insert_sort_by_time(vmem_t *vmp, vmem_seg_t *vsp)
 
 	ASSERT(vsp->vs_span_createtime != 0);
 	if (vsp->vs_span_createtime == 0) {
-		dprintf("SPL: %s: WARNING: vsp->vs_span_createtime == 0 (%s)!\n",
-		    __func__, vmp->vm_name);
+		TraceEvent(TRACE_WARNING, "SPL: %s: WARNING: vsp->vs_span_createtime == 0 (%s)!\n",
+		           __func__, vmp->vm_name);
 	}
 
 	// continuing our example, starts with p at flist[8k]
@@ -3064,13 +3066,13 @@ static uint64_t
 spl_validate_bucket_span_size(uint64_t val)
 {
 	if (!ISP2(val)) {
-		dprintf("SPL: %s: WARNING %llu is not a power of two, not changing.\n",
-		    __func__, val);
+		TraceEvent(TRACE_WARNING, "SPL: %s: WARNING %llu is not a power of two, not changing.\n",
+		           __func__, val);
 		return (0);
 	}
 	if (val < 128ULL*1024ULL || val > 16ULL*1024ULL*1024ULL) {
-		dprintf("SPL: %s: WARNING %llu is out of range [128k - 16M], not changing.\n",
-		    __func__, val);
+		TraceEvent(TRACE_WARNING, "SPL: %s: WARNING %llu is out of range [128k - 16M], not changing.\n",
+		           __func__, val);
 		return (0);
 	}
 	return (val);

--- a/ZFSin/spl/module/spl/spl-vnode.c
+++ b/ZFSin/spl/module/spl/spl-vnode.c
@@ -41,6 +41,7 @@
 #include <sys/zfs_znode.h>
 #endif
 
+#include <Trace.h>
 
 //#define FIND_MAF
 
@@ -1360,7 +1361,7 @@ int vnode_drain_delayclose(int force)
 			(vp->SectionObjectPointers.ImageSectionObject == NULL) &&
 			(vp->SectionObjectPointers.DataSectionObject == NULL)) {
 			// We are ready to let go
-			dprintf("%s: drain %vp\n", __func__, vp);
+			dprintf("%s: drain %p\n", __func__, vp);
 
 			// Pass VNODELOCKED as we hold vp, recycle will unlock.
 			// We have to give up all_list due to recycle -> reclaim -> rmnode -> purgedir -> zget -> vnode_create

--- a/ZFSin/spl/module/spl/spl-windows.c
+++ b/ZFSin/spl/module/spl/spl-windows.c
@@ -69,6 +69,7 @@ uint64_t spl_GetPhysMem(void);
 #define	_task_user_
 //#include <IOKit/IOLib.h>
 
+#include <Trace.h>
 
 // Size in bytes of the memory allocated in seg_kmem
 extern uint64_t		segkmem_total_mem_allocated;
@@ -250,7 +251,7 @@ ddi_copyin(const void *from, void *to, size_t len, int flags)
 		error = GetExceptionCode();
 	}
 	if (error) {
-		dprintf("SPL: Exception while accessing inBuf 0X%08X\n", error);
+		TraceEvent(TRACE_ERROR, "SPL: Exception while accessing inBuf 0X%08X\n", error);
 		goto out;
 	}
 
@@ -268,7 +269,7 @@ ddi_copyin(const void *from, void *to, size_t len, int flags)
 		error = GetExceptionCode();
 	}
 	if (error) {
-		dprintf("SPL: Exception while locking inBuf 0X%08X\n", error);
+		TraceEvent(TRACE_ERROR, "SPL: Exception while locking inBuf 0X%08X\n", error);
 		goto out;
 	}
 
@@ -318,7 +319,7 @@ ddi_copyout(const void *from, void *to, size_t len, int flags)
 	mdl = IoAllocateMdl(to, len, FALSE, FALSE, NULL);
 	if (!mdl) {
 		error = STATUS_INSUFFICIENT_RESOURCES;
-		dprintf("SPL: copyout failed to allocate mdl\n");
+		TraceEvent(TRACE_ERROR, "SPL: copyout failed to allocate mdl\n");
 		goto out;
 	}
 
@@ -330,7 +331,7 @@ ddi_copyout(const void *from, void *to, size_t len, int flags)
 		error = GetExceptionCode();
 	}
 	if (error != 0) {
-		dprintf("SPL: Exception while locking outBuf 0X%08X\n",
+		TraceEvent(TRACE_ERROR, "SPL: Exception while locking outBuf 0X%08X\n",
 			error);
 		goto out;
 	}
@@ -377,7 +378,7 @@ ddi_copysetup(void *to, size_t len, void **out_buffer, PMDL *out_mdl)
 		error = GetExceptionCode();
 	}
 	if (error) {
-		dprintf("SPL: Exception while accessing inBuf 0X%08X\n", error);
+		TraceEvent(TRACE_ERROR, "SPL: Exception while accessing inBuf 0X%08X\n", error);
 		goto out;
 	}
 
@@ -389,14 +390,14 @@ ddi_copysetup(void *to, size_t len, void **out_buffer, PMDL *out_mdl)
 		error = GetExceptionCode();
 	}
 	if (error) {
-		dprintf("SPL: Exception while accessing inBuf 0X%08X\n", error);
+		TraceEvent(TRACE_ERROR, "SPL: Exception while accessing inBuf 0X%08X\n", error);
 		goto out;
 	}
 
 	mdl = IoAllocateMdl(to, len, FALSE, FALSE, NULL);
 	if (!mdl) {
 		error = STATUS_INSUFFICIENT_RESOURCES;
-		dprintf("SPL: copyout failed to allocate mdl\n");
+		TraceEvent(TRACE_ERROR, "SPL: copyout failed to allocate mdl\n");
 		goto out;
 	}
 
@@ -408,7 +409,7 @@ ddi_copysetup(void *to, size_t len, void **out_buffer, PMDL *out_mdl)
 		error = GetExceptionCode();
 	}
 	if (error != 0) {
-		dprintf("SPL: Exception while locking outBuf 0X%08X\n",
+		TraceEvent(TRACE_ERROR, "SPL: Exception while locking outBuf 0X%08X\n",
 			error);
 		goto out;
 	}
@@ -636,7 +637,7 @@ uint64_t spl_GetPhysMem(void)
 		query, NULL, NULL);
 
 	if (status != STATUS_SUCCESS) {
-		dprintf("%s: size query failed: 0x%x\n", __func__, status);
+		TraceEvent(TRACE_ERROR, "%s: size query failed: 0x%x\n", __func__, status);
 		return 0ULL;
 	}
 

--- a/ZFSin/spl/module/spl/spl-xdr.c
+++ b/ZFSin/spl/module/spl/spl-xdr.c
@@ -32,6 +32,7 @@
 #include <spl-debug.h>
 #include <sys/byteorder.h>
 
+#include <Trace.h>
 
 /*
  * SPL's XDR mem implementation.
@@ -148,7 +149,7 @@ xdrmem_create(XDR *xdrs, const caddr_t addr, const uint_t size,
 			xdrs->x_ops = &xdrmem_decode_ops;
 			break;
 		default:
-			dprintf("SPL: Invalid op value: %d\n", op);
+			TraceEvent(TRACE_ERROR, "SPL: Invalid op value: %d\n", op);
 			xdrs->x_ops = NULL; /* Let the caller know we failed */
 			return;
 	}
@@ -158,7 +159,7 @@ xdrmem_create(XDR *xdrs, const caddr_t addr, const uint_t size,
 	xdrs->x_addr_end = addr + size;
 
 	if (xdrs->x_addr_end < xdrs->x_addr) {
-		dprintf("SPL: Overflow while creating xdrmem: %p, %u\n", addr, size);
+		TraceEvent(TRACE_ERROR, "SPL: Overflow while creating xdrmem: %p, %u\n", addr, size);
 		xdrs->x_ops = NULL;
 	}
 }
@@ -170,7 +171,7 @@ xdrmem_control(XDR *xdrs, int req, void *info)
 	struct xdr_bytesrec *rec = (struct xdr_bytesrec *) info;
 
 	if (req != XDR_GET_BYTES_AVAIL) {
-		dprintf("SPL: Called with unknown request: %d\n", req);
+		TraceEvent(TRACE_ERROR, "SPL: Called with unknown request: %d\n", req);
 		return FALSE;
 	}
 

--- a/ZFSin/zfs/include/sys/zfs_context_kernel.h
+++ b/ZFSin/zfs/include/sys/zfs_context_kernel.h
@@ -118,6 +118,7 @@ typedef struct direntry dirent64_t;
 
 extern PDRIVER_OBJECT WIN_DriverObject;
 
+#include <Trace.h>
 
 #endif /* _KERNEL */
 


### PR DESCRIPTION
Enable WPP tracing to collect trace logs to an etl file

Below files are excluded from WPP tracing either because of format specifier "%.*S" not being supported by WPP or in case of arc.c, there is a macro arc_c defined in arc.c which does not allow the expansion of the function (dprintf or TraceEvent) in the desired way.

arc.c
dsl_proc.c
zfs_acl.c
zfs_ioctl.c
zfs_vfsops.c
zfs_vnops.c
zfs_vnops_windows.c
zfs_vnops_windows_lib.c
zfs_vnops_windows_mount.c
zfs_windows_zvol.c
zfs_znode.c

By default, the project settings of Release build has WPP enabled while that for Debug, it is disabled.
WPP can be enabled in Debug build as well if required.
To enable Wpp, Select Yes under 'Run Wpp Tracing' in Project properties; Define both RUN_WPP and WPPFILE="%(FileName).tmh" in C/C++ preprocessor