### PR TITLE
Don't return error when mountpoint is not mountable

### DIFF
--- a/ZFSin/zfs/lib/libzfs/libzfs_mount.c
+++ b/ZFSin/zfs/lib/libzfs/libzfs_mount.c
@@ -805,8 +805,7 @@ zfs_mount(zfs_handle_t *zhp, const char *options, int flags)
 #endif /* __LINUX__ */
 
 	if (!zfs_is_mountable(zhp, mountpoint, sizeof (mountpoint), NULL))
-		return (zfs_error_fmt(hdl, EZFS_MOUNTFAILED,
-			dgettext(TEXT_DOMAIN, "cannot mount '%s'"), mountpoint));
+		return (0);
 
 #ifdef __LINUX__
 


### PR DESCRIPTION
While creating zpool with `-m none` it returns error with message "cannot mount 'none': mount failed".

This patch fixes it by returning 0 when the mountpoint is not mountable. This in line with [OpenZFS](https://github.com/openzfs/zfs/blob/master/lib/libzfs/libzfs_mount.c#L371-L373).