### PR TITLE
zpool import after a system reboot causing panic when there is unflushed data in the zil.

### DIFF
--- a/ZFSin/zfs/module/zfs/zvol.c
+++ b/ZFSin/zfs/module/zfs/zvol.c
@@ -452,7 +452,7 @@ zvol_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 	if (error) {
 		dmu_tx_abort(tx);
 	} else {
-		dmu_write_by_dnode(zv->zv_dn, offset, length, data, tx);
+		dmu_write(os, ZVOL_OBJ, offset, length, data, tx);
 		dmu_tx_commit(tx);
 	}
 


### PR DESCRIPTION
create a zvol with sync=always option, now do some writes to the zvol and hard reboot the system. Once the system comes back do a zpool import <pool name>, this will causing panic.

Reason is in 'zvol_replay_write' we are using 'dmu_write_by_dnode', with  zv->zv_dn(dnode) as first argument, but  at this point dnode is not initialised. So instead of using  dmu_write_by_dnode we should use 'dmu_write'.

After this fix, system is stable.


