### PR TITLE
Trigger low_mem_event during zvol delete

### DIFF
--- a/ZFSin/spl/module/spl/spl-kmem.c
+++ b/ZFSin/spl/module/spl/spl-kmem.c
@@ -78,7 +78,7 @@ static volatile _Atomic int64_t spl_free;
 int64_t spl_free_delta_ema;
 
 static boolean_t spl_event_thread_exit = FALSE;
-static PKEVENT low_mem_event = NULL;
+PKEVENT low_mem_event = NULL;
 
 static volatile _Atomic int64_t spl_free_manual_pressure = 0;
 static volatile _Atomic boolean_t spl_free_fast_pressure = FALSE;

--- a/ZFSin/zfs/module/zfs/zfs_ioctl.c
+++ b/ZFSin/zfs/module/zfs/zfs_ioctl.c
@@ -3927,6 +3927,7 @@ zfs_ioc_pool_discard_checkpoint(const char *poolname, nvlist_t *innvl,
  *
  * outputs:		none
  */
+extern PKEVENT low_mem_event;
 static int
 zfs_ioc_destroy(zfs_cmd_t *zc)
 {
@@ -3954,6 +3955,14 @@ zfs_ioc_destroy(zfs_cmd_t *zc)
 #endif
 
 		err = dsl_destroy_head(zc->zc_name);
+		if(err == 0) {
+			/*
+			 * Trigger a low_mem_even, so that we relase all the
+			 * ununsed memory to the system.
+			 */
+			xprintf("%s triggering low_mem_event to release ununsed memory\n", __func__);
+			KeSetEvent(low_mem_event, 0, FALSE);
+		}
 
 #if 0 // consider fixing the zvol again if the destroy failed
 		if (err != 0 && zv != NULL) {


### PR DESCRIPTION
in zfs destroy, trigger low_mem_event, so that zfs could release all the unused memory to the system. Currently zfs ls holding the memory even when there is no zvol.
