### PR TITLE
Trigger reap_cache periodically to release unused memory to the system

### DIFF
--- a/ZFSin/zfs/module/zfs/zfs_ioctl.c
+++ b/ZFSin/zfs/module/zfs/zfs_ioctl.c
@@ -3927,6 +3927,7 @@ zfs_ioc_pool_discard_checkpoint(const char *poolname, nvlist_t *innvl,
  *
  * outputs:		none
  */
+extern PKEVENT low_mem_event;
 static int
 zfs_ioc_destroy(zfs_cmd_t *zc)
 {
@@ -3954,6 +3955,14 @@ zfs_ioc_destroy(zfs_cmd_t *zc)
 #endif
 
 		err = dsl_destroy_head(zc->zc_name);
+		if(err == 0) {
+			/*
+			 * Trigger a low_mem_even, so that we relase all the
+			 * ununsed memory to the system.
+			 */
+			xprintf("%s triggering low_mem_event to release ununsed memory\n", __func__);
+			KeSetEvent(low_mem_event, 0, FALSE);
+		}
 
 #if 0 // consider fixing the zvol again if the destroy failed
 		if (err != 0 && zv != NULL) {


### PR DESCRIPTION
1. zvol delete to trigger low_mem_event to release unused memory to the system.
2. 'spl_free_thread' to call 'spl_free_reap_caches' periodically to release unused memory to the system.