### PR TITLE
Fix building with CMake

### DIFF
--- a/ZFSin/CMakeLists.txt
+++ b/ZFSin/CMakeLists.txt
@@ -103,6 +103,9 @@ function(um_add_executable name)
 endfunction()
 
 include_directories(BEFORE zfs/include)
+
+set(ZFSin_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
 add_subdirectory(spl)
 add_subdirectory(zfs)
 

--- a/ZFSin/spl/module/spl/CMakeLists.txt
+++ b/ZFSin/spl/module/spl/CMakeLists.txt
@@ -28,4 +28,4 @@ wdk_add_library(splkern
   spl-xdr.c
 )
 
-target_include_directories(splkern BEFORE PUBLIC ../../include)
+target_include_directories(splkern BEFORE PUBLIC ../../include "${ZFSin_ROOT_DIR}")

--- a/ZFSin/zfs/include/sys/edonr.h
+++ b/ZFSin/zfs/include/sys/edonr.h
@@ -44,6 +44,10 @@ extern "C" {
 #include <stdlib.h> /* size_t ... */
 #endif
 
+#ifdef pipe
+#undef pipe
+#endif
+
 /*
  * EdonR allows to call EdonRUpdate() consecutively only if the total length
  * of stored unprocessed data and the new supplied data is less than or equal

--- a/ZFSin/zfs/lib/libspl/include/sys/edonr.h
+++ b/ZFSin/zfs/lib/libspl/include/sys/edonr.h
@@ -40,6 +40,10 @@ extern "C" {
 #include <sys/types.h>
 #include <sys/w32_types.h>
 
+#ifdef pipe
+#undef pipe
+#endif
+
 /*
  * EdonR allows to call EdonRUpdate() consecutively only if the total length
  * of stored unprocessed data and the new supplied data is less than or equal

--- a/ZFSin/zfs/lib/libspl/include/wosix.h
+++ b/ZFSin/zfs/lib/libspl/include/wosix.h
@@ -49,6 +49,7 @@ extern int wosix_isatty(int fd);
 extern int wosix_mkdir(const char *path, mode_t mode);
 extern int wosix_pwrite(int fd, const void *buf, size_t nbyte, off_t offset);
 extern int wosix_pread(int fd, void *buf, size_t nbyte, off_t offset);
+extern int wosix_stat(char* path, struct _stat64* st);
 extern int wosix_fstat(int fd, struct _stat64 *st);
 extern int wosix_fstat_blk(int fd, struct _stat64 *st);
 extern uint64_t wosix_lseek(int fd, uint64_t offset, int seek);

--- a/ZFSin/zfs/module/icp/algs/edonr/edonr.c
+++ b/ZFSin/zfs/module/icp/algs/edonr/edonr.c
@@ -41,6 +41,10 @@
 /* big endian support, provides no-op's if run on little endian hosts */
 #include "edonr_byteorder.h"
 
+#ifdef pipe
+#undef pipe
+#endif
+
 #define	hashState224(x)	((x)->pipe->p256)
 #define	hashState256(x)	((x)->pipe->p256)
 #define	hashState384(x)	((x)->pipe->p512)

--- a/ZFSin/zfs/module/zfs/CMakeLists.txt
+++ b/ZFSin/zfs/module/zfs/CMakeLists.txt
@@ -124,6 +124,7 @@ wdk_add_library(zfskern
   zrlock.c
   zthr.c
   zvol.c
+  zfs_file.c
 )
 
 target_link_libraries(zfskern PRIVATE splkern icpkern)

--- a/zfsinstaller/CMakeLists.txt
+++ b/zfsinstaller/CMakeLists.txt
@@ -3,7 +3,7 @@ um_add_executable(zfsinstaller
 	zfsinstaller.h
 )
 target_compile_definitions(zfsinstaller PRIVATE UNICODE _UNICODE)
-target_link_libraries(zfsinstaller setupapi)
+target_link_libraries(zfsinstaller setupapi libspl)
 install(TARGETS zfsinstaller RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}/driver")
 install(FILES $<TARGET_PDB_FILE:zfsinstaller>
 	DESTINATION "${CMAKE_INSTALL_BINDIR}/driver"


### PR DESCRIPTION
- `Trace.h` was not found, 
- missing prototype for `wosix_stat`
- `#define pipe` gets expanded in macros inside `edonr.c`
- link `zfsinstaller` to libspl for getopt