### PR TITLE
Fix arc kstat updates

### DIFF
--- a/ZFSin/zfs/module/zfs/zfs_kstat_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_kstat_windows.c
@@ -216,6 +216,10 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 		zfs_vnop_skip_unlinked_drain = ks->win32_skip_unlinked_drain.value.ui64;
 		zfs_vfs_sync_paranoia = ks->win32_use_system_sync.value.ui64;
 
+		/* ARC */
+		arc_kstat_update(ksp, rw);
+		arc_kstat_update_osx(ksp, rw);
+
 		/* L2ARC */
 		l2arc_write_max = ks->l2arc_write_max.value.ui64;
 		l2arc_write_boost = ks->l2arc_write_boost.value.ui64;
@@ -410,6 +414,10 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 		ks->win32_force_formd_normalized.value.ui64 = zfs_vnop_force_formd_normalized_output;
 		ks->win32_skip_unlinked_drain.value.ui64    = zfs_vnop_skip_unlinked_drain;
 		ks->win32_use_system_sync.value.ui64 = zfs_vfs_sync_paranoia;
+
+		/* ARC */
+		arc_kstat_update(ksp, rw);
+		arc_kstat_update_osx(ksp, rw);
 
 		/* L2ARC */
 		ks->l2arc_write_max.value.ui64               = l2arc_write_max;


### PR DESCRIPTION
This patch partially reverts commit 88d37b7a1ae78ae36bfac16e7602885f54b266cc
The issue was that the os_mem_alloc was keeping on increasing when IO
workload was running, not honouring zfs_arc_max and zfs_arc_meta_limit.