### PR TITLE
metaslab_unload_delay tunable through kstat

### DIFF
--- a/ZFSin/zfs/include/sys/kstat_windows.h
+++ b/ZFSin/zfs/include/sys/kstat_windows.h
@@ -153,6 +153,7 @@ typedef struct osx_kstat {
 
 	kstat_named_t zfs_vdev_initialize_value;
 	kstat_named_t zfs_autoimport_disable;
+	kstat_named_t metaslab_unload_delay;
 } osx_kstat_t;
 
 
@@ -266,6 +267,7 @@ extern uint64_t zfs_disable_removablemedia;
 
 extern uint64_t zfs_initialize_value;
 extern int zfs_autoimport_disable;
+extern int metaslab_unload_delay;
 
 int        kstat_osx_init(void *);
 void       kstat_osx_fini(void);

--- a/ZFSin/zfs/module/zfs/metaslab.c
+++ b/ZFSin/zfs/module/zfs/metaslab.c
@@ -2889,7 +2889,6 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 	 * If the metaslab is loaded and we've not tried to load or allocate
 	 * from it in 'metaslab_unload_delay' txgs, then unload it.
 	 */
-	dprintf("metaslab unload delay is %d\n", metaslab_unload_delay);
 	if (msp->ms_loaded &&
 	    msp->ms_disabled == 0 &&
 	    msp->ms_selected_txg + metaslab_unload_delay < txg) {

--- a/ZFSin/zfs/module/zfs/metaslab.c
+++ b/ZFSin/zfs/module/zfs/metaslab.c
@@ -36,6 +36,7 @@
 #include <sys/zfeature.h>
 #include <sys/vdev_indirect_mapping.h>
 #include <sys/zap.h>
+#include <sys/kstat_windows.h>
 
 #define	WITH_DF_BLOCK_ALLOCATOR
 
@@ -2888,6 +2889,7 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 	 * If the metaslab is loaded and we've not tried to load or allocate
 	 * from it in 'metaslab_unload_delay' txgs, then unload it.
 	 */
+	dprintf("metaslab unload delay is %d\n", metaslab_unload_delay);
 	if (msp->ms_loaded &&
 	    msp->ms_disabled == 0 &&
 	    msp->ms_selected_txg + metaslab_unload_delay < txg) {

--- a/ZFSin/zfs/module/zfs/zfs_kstat_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_kstat_windows.c
@@ -183,7 +183,7 @@ osx_kstat_t osx_kstat = {
 	{ "zfs_disable_removablemedia",		KSTAT_DATA_UINT64 },
 	{ "zfs_vdev_initialize_value",		KSTAT_DATA_UINT64 },
 	{ "zfs_autoimport_disable",		KSTAT_DATA_UINT64 },
-		
+	{ "metaslab_unload_delay",		KSTAT_DATA_UINT64 },	
 };
 
 
@@ -393,7 +393,8 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 			ks->zfs_vdev_initialize_value.value.ui64;
 		zfs_autoimport_disable =
 			ks->zfs_autoimport_disable.value.ui64;
-
+		metaslab_unload_delay =
+			ks->metaslab_unload_delay.value.ui64;
 	} else {
 
 		/* kstat READ */
@@ -583,6 +584,8 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 			zfs_initialize_value;
 		ks->zfs_autoimport_disable.value.ui64 =
 			zfs_autoimport_disable;
+		ks->metaslab_unload_delay.value.ui64 =
+			metaslab_unload_delay;	
 	}
 
 	return 0;


### PR DESCRIPTION
By default for a maximum of 8 txg a metaslab can remain loaded in memory without having any allocations from it. 
This number can be too low for some system which can be a potentially load/unload metaslabs too frequently and therefore we leave it to user's choice by making it tunable through kstat.