### PR TITLE
Fixed crash in (debug build) zdb -R <poolname> <vdev>:<offset>:<size>

### DIFF
--- a/ZFSin/zfs/cmd/zdb/zdb.c
+++ b/ZFSin/zfs/cmd/zdb/zdb.c
@@ -5072,7 +5072,7 @@ zdb_dump_block(char *label, void *buf, uint64_t size, int flags)
 	int do_bswap = !!(flags & ZDB_FLAG_BSWAP);
 	unsigned i, j;
 	const char *hdr;
-	char *c;
+	unsigned char *c;
 
 
 	if (do_bswap)
@@ -5088,7 +5088,7 @@ zdb_dump_block(char *label, void *buf, uint64_t size, int flags)
 		    (u_longlong_t)(do_bswap ? BSWAP_64(d[i]) : d[i]),
 		    (u_longlong_t)(do_bswap ? BSWAP_64(d[i + 1]) : d[i + 1]));
 
-		c = (char *)&d[i];
+		c = (unsigned char *)&d[i];
 		for (j = 0; j < 2 * sizeof (uint64_t); j++)
 			(void) printf("%c", isprint(c[j]) ? c[j] : '.');
 		(void) printf("\n");


### PR DESCRIPTION
This fix was required due to a bug in isprint() library function (debug mode) in Visual Studio