### PR TITLE
Fixed a race condition in 'spl_cv_wait' that could potentially cause a thread to miss a broadcast event

### DIFF
--- a/ZFSin/spl/include/osx/condvar.h
+++ b/ZFSin/spl/include/osx/condvar.h
@@ -19,7 +19,7 @@ enum {
 struct cv {
 	KEVENT kevent[CV_MAX_EVENTS]; // signal event, broadcast event
 	KSPIN_LOCK waiters_count_lock;
-	uint32_t waiters_count;
+	volatile uint32_t waiters_count;
 	uint32_t initialised; // Just used as sanity
 };
 


### PR DESCRIPTION
Moved mutex_enter above waiters_count == 1 check in spl_cv_wait, to avoid the possibility of current thread wrongly detecting that is the only thread waiting for the event while there could be another  thread that acquired the mutex and is about to increment the  'waiters_count' a few lines above.