### PR TITLE
Periodically calling 'vmem_update' function to dynamically update vmem->vm_hash_table size

### DIFF
--- a/ZFSin/spl/module/spl/spl-kmem.c
+++ b/ZFSin/spl/module/spl/spl-kmem.c
@@ -130,6 +130,8 @@ static const char *KMEM_VA_PREFIX = "kmem_va";
 static const char *KMEM_MAGAZINE_PREFIX = "kmem_magazine_";
 
 static char kext_version[64] = SPL_META_VERSION "-" SPL_META_RELEASE SPL_DEBUG_STR;
+extern boolean_t hash_rescale_exit;
+extern kmutex_t vmem_list_lock;
 
 //struct sysctl_oid_list sysctl__spl_children;
 //SYSCTL_DECL(_spl);
@@ -5448,6 +5450,9 @@ spl_kmem_thread_fini(void)
 	dprintf("SPL: spl_free_thread stop: destroying cv and mutex\n");
 	cv_destroy(&spl_free_thread_cv);
 	mutex_destroy(&spl_free_thread_lock);
+	mutex_enter(&vmem_list_lock);
+	hash_rescale_exit = TRUE;
+	mutex_exit(&vmem_list_lock);
 
 	dprintf("SPL: bsd_untimeout\n");
 


### PR DESCRIPTION
Currently 'vmp->vm_hash_table' size is 16, due to which the lookup time is too high when the number of objects are more. We have seen ZFSin uninstallation taking more than (~30 min) when the arc usage is ~40GB. 
During the analysis we saw the while loop inside 'vmem_hash_delete'  taking most of the time.
prev_vspp = VMEM_HASH(vmp, addr);
while ((vsp = *prev_vspp) != NULL) {
                if (vsp->vs_start == addr) {
                        *prev_vspp = vsp->vs_knext;
                        break;
                }
                vmp->vm_kstat.vk_lookup.value.ui64++;
                prev_vspp = &vsp->vs_knext;
        }


So enabled 'vmem_update' function to periodically call 'vmem_hash_rescale' to update the hash_table size every 60 sec. After the fix, vm_hash_table size is much bigger and the lookup time has been reduced considerably, also the uninstallation process is very fast.