### PR TITLE
 Fixed ZFSin going to an infinate loop when the underlying disk returns error

### DIFF
--- a/ZFSin/zfs/module/zfs/zfs_ioctl.c
+++ b/ZFSin/zfs/module/zfs/zfs_ioctl.c
@@ -5495,7 +5495,8 @@ zfs_ioc_clear(zfs_cmd_t *zc)
 
 	vdev_clear(spa, vd);
 
-	(void) spa_vdev_state_exit(spa, spa->spa_root_vdev, 0);
+	(void) spa_vdev_state_exit(spa, spa_suspended(spa) ?
+            NULL : spa->spa_root_vdev, 0);
 
 	/*
 	 * Resume any suspended I/Os.

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
@@ -199,6 +199,7 @@ wzvol_HwFindAdapter(
 	pConfigInfo->VirtualDevice = TRUE;                        // Inidicate no real hardware.
 	pConfigInfo->WmiDataProvider = TRUE;                        // Indicate WMI provider.
 	pConfigInfo->MaximumTransferLength = SP_UNINITIALIZED_VALUE;      // Indicate unlimited.
+	pConfigInfo->NumberOfPhysicalBreaks = 0x21;                       // 128K IO size
 	pConfigInfo->AlignmentMask = 0x3;                         // Indicate DWORD alignment.
 	pConfigInfo->CachesData = FALSE;                       // Indicate miniport wants flush and shutdown notification.
 	pConfigInfo->ScatterGather = TRUE;                        // Indicate scatter-gather (explicit setting needed for Win2003 at least).

--- a/ZFSin/zfs/module/zfs/zio.c
+++ b/ZFSin/zfs/module/zfs/zio.c
@@ -2130,7 +2130,7 @@ zio_suspend(spa_t *spa, zio_t *zio, zio_suspend_reason_t reason)
 		    "failure and the failure mode property for this pool "
 		    "is set to panic.", spa_name(spa));
 
-	cmn_err(CE_WARN, "Pool '%s' has encountered an uncorrectable I/O "
+	dprintf("Pool '%s' has encountered an uncorrectable I/O "
 	    "failure and has been suspended.\n", spa_name(spa));
 
 	zfs_ereport_post(FM_EREPORT_ZFS_IO_FAILURE, spa, NULL,
@@ -3605,7 +3605,7 @@ zio_vdev_io_done(zio_t *zio)
 
 	ops->vdev_op_io_done(zio);
 
-	if (unexpected_error && zio->io_waiter != NULL)
+	if (unexpected_error)
 		VERIFY(vdev_probe(vd, zio) == NULL);
 
 	return (zio);


### PR DESCRIPTION
 Fixed ZFSin going to an infinate loop when the underlying disk returns error, and causing data loss.
  Also fixed 'zpool clear' command not working on ZFSin.