### PR TITLE
assign targetId and lun to zvol after it is open

### DIFF
--- a/ZFSin/zfs/module/zfs/zvol.c
+++ b/ZFSin/zfs/module/zfs/zvol.c
@@ -642,10 +642,6 @@ zvol_create_minor_impl(const char *name)
 	    offsetof(zvol_extent_t, ze_node));
 	rangelock_init(&zv->zv_rangelock, NULL, NULL);
 
-	// Assign new TargetId and Lun
-	wzvol_assign_targetid(zv);
-
-
 	/* get and cache the blocksize */
 	error = dmu_object_info(os, ZVOL_OBJ, &doi);
 	ASSERT(error == 0);
@@ -698,6 +694,9 @@ zvol_create_minor_impl(const char *name)
 	// Announcing new DISK - we hold the zvol open the entire time storport has it.
 	error = zvol_open_impl(zv, FWRITE, 0, NULL);
 	
+	// Assign new TargetId and Lun
+	wzvol_assign_targetid(zv);
+
 	return (0);
 }
 

--- a/ZFSin/zfs/module/zfs/zvol.c
+++ b/ZFSin/zfs/module/zfs/zvol.c
@@ -694,8 +694,10 @@ zvol_create_minor_impl(const char *name)
 	// Announcing new DISK - we hold the zvol open the entire time storport has it.
 	error = zvol_open_impl(zv, FWRITE, 0, NULL);
 	
-	// Assign new TargetId and Lun
-	wzvol_assign_targetid(zv);
+	if (error == 0) {
+		// Assign new TargetId and Lun
+		wzvol_assign_targetid(zv);
+	}
 
 	return (0);
 }


### PR DESCRIPTION
As discussed in issue https://github.com/openzfsonwindows/ZFSin/issues/341, created the PR for the changes.

Issue:
TargetId and Lun is created for zvol before it is fully open. 

Changes:-
Moved the  assign to after the zvol_open_impl() call.